### PR TITLE
fix: export all files from root dir

### DIFF
--- a/checker/actions/export.py
+++ b/checker/actions/export.py
@@ -25,7 +25,7 @@ def _get_enabled_files_and_dirs_private_to_public(
     # Common staff; files only, all from private repo except ignored
     common_files: dict[Path, Path] = {
         i: public_course_driver.root_dir / i.name
-        for i in private_course_driver.root_dir.glob('*.*')
+        for i in private_course_driver.root_dir.glob('*')
         if i.is_file() and not filename_match_patterns(i, EXPORT_IGNORE_COMMON_FILE_PATTERNS)
     }
 


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗
Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple prs instead of opening a huge one. -->

<!-- Feel free to set Draft status if you need help or want to discuss something before submitting the pull request. -->

<!-- If this pull request closes an issue, please mention the issue number below -->

## Description

<!-- Describe the specific changes that have been made in this pull 
request. Provide details on the approach taken to address the problem 
and any notable implementation details. -->
For some reason files in the root directory without `.` in their name were not exported. I doubt that any of the existing project need it to work this way.

## Contribution Checklist

General
- [x] I have read and agreed on the [CONTRIBUTING](../CONTRIBUTING.md) and [CODE OF CONDUCT](../CODE_OF_CONDUCT.md) documents.
- [x] I have run linters, type checks, import sorting and tests locally.
- [x] I have added comments to code in hard-to-understand areas.
- [x] Pull Request title uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format: `tag(scope): description`.

Added tests?
- [ ] yes
- [ ] partially, will add more later
- [ ] no, because I need help
- [x] no, because they aren't needed

Added to documentation?
- [ ] README.md
- [ ] `docs/`
- [ ] `manytask.github.io` page
- [ ] no documentation needed


## [optional] What gif best describes this PR or how it makes you feel? <!-- delete section if not needed -->
![](https://media.giphy.com/media/KD7Ud1YX1nYRkb2r29/giphy.gif)