### PR TITLE
feat(testers): add external testers

### DIFF
--- a/checker/__main__.py
+++ b/checker/__main__.py
@@ -94,7 +94,8 @@ def check(
         deadlines_config=private_course_driver.get_deadlines_file_path(),
     )
     tester = Tester.create(
-        system=course_config.system,
+        root=root,
+        course_config=course_config,
         cleanup=not no_clean,
         dry_run=dry_run,
     )
@@ -157,7 +158,8 @@ def grade(
         deadlines_config=private_course_driver.get_deadlines_file_path(),
     )
     tester = Tester.create(
-        system=course_config.system,
+        root=execution_folder,
+        course_config=course_config,
     )
 
     grade_on_ci(

--- a/checker/course/config.py
+++ b/checker/course/config.py
@@ -48,6 +48,7 @@ class CourseConfig:
     # checker default
     layout: str = 'groups'
     executor: str = 'sandbox'
+    tester_path: str | None = None
 
     # info
     links: dict[str, str] | None = None

--- a/checker/testers/tester.py
+++ b/checker/testers/tester.py
@@ -114,7 +114,7 @@ class Tester:
         elif system == 'external':
             path = course_config.tester_path
             if path is None:
-                raise TesterNotImplemented(f'tester_path is not specified in course config')
+                raise TesterNotImplemented('tester_path is not specified in course config')
             return _create_external_tester(root / path, cleanup=cleanup, dry_run=dry_run)
         else:
             raise TesterNotImplemented(f'Tester for <{system}> are not supported right now')

--- a/checker/testers/tester.py
+++ b/checker/testers/tester.py
@@ -5,7 +5,7 @@ import tempfile
 from abc import abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 from ..course import CourseConfig
 from ..exceptions import RunFailedError, TaskTesterTestConfigException, TesterNotImplemented
@@ -13,8 +13,8 @@ from ..executors.sandbox import Sandbox
 from ..utils.print import print_info
 
 
-def _create_external_tester(tester_path: Path, dry_run: bool, cleanup: bool):
-    globls = {}
+def _create_external_tester(tester_path: Path, dry_run: bool, cleanup: bool) -> Tester:
+    globls: Dict[str, Any] = {}
     with open(tester_path) as f:
         tester_code = compile(f.read(), tester_path.absolute(), 'exec')
         exec(tester_code, globls)


### PR DESCRIPTION
## Description
This PR adds support for testers which can be defined everywhere in course repository by user without the need to change checker's code.

## Motivation and Context
Standard testers (make, python and cpp) are very limited in capabilities and adding extra logic to them could be very difficult for new users.

## Contribution Checklist

General
- [x] I have read and agreed on the [CONTRIBUTING](../CONTRIBUTING.md) and [CODE OF CONDUCT](../CODE_OF_CONDUCT.md) documents.
- [x] I have run linters, type checks, import sorting and tests locally.
- [x] I have added comments to code in hard-to-understand areas.
- [x] Pull Request title uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format: `tag(scope): description`.

Added tests?
- [x] yes
- [ ] partially, will add more later
- [ ] no, because I need help
- [ ] no, because they aren't needed

Added to documentation?
- [ ] README.md
- [ ] `docs/`
- [ ] `manytask.github.io` page
- [ ] no documentation needed
