### PR TITLE
ci(pypi): use Trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,11 @@ jobs:
   release-python-package:
     needs: update-version-and-changelog-files
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/manytask-checker
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
@@ -60,9 +65,6 @@ jobs:
         python -m pip wheel . --no-deps --wheel-dir dist
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_TOKEN }}
-        packages_dir: dist
 
 #  release-github-pages:
 #    runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗
Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
Feel free to set Draft status if you need help or want to discuss. -->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #39 


## Description

<!-- Which changes sre suggested? How specific behaviour will change? -->
Use Trusted publishing for `manytask-checker` package.


## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Trusted publishing is a new recommended way to publish python packages.
https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/


## Contribution Checklist

General
- [x] I have read and agreed on the [CONTRIBUTING](../CONTRIBUTING.md) and [CODE OF CONDUCT](../CODE_OF_CONDUCT.md) documents.
- [x] I have run linters, type checks, import sorting and tests locally.
- [x] I have added comments to code in hard-to-understand areas.
- [x] Pull Request title uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format: `tag(scope): description`.

Added tests?
- [ ] yes
- [ ] partially, will add more later
- [ ] no, because I need help
- [x] no, because they aren't needed

Added to documentation?
- [ ] README.md
- [ ] `docs/`
- [ ] `manytask.github.io` page
- [x] no documentation needed
