### PR TITLE
feat(plugin): add sandbox plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
           cache: 'pip' # caching pip dependencies
       - name: Install dependencies
         run: |
+          sudo apt-get install -y firejail
           python -m pip install -e .[test]
       - name: Run all tests
         run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,34 @@
 ARG PYTHON_VERSION=3.12
 
-# Stage 1: Build stage
+# Stage 1: Python dependencies
 FROM python:${PYTHON_VERSION}-alpine as builder
-
-WORKDIR /usr/src/app
 
 # Install build tools for cpp and rust
 RUN apk update && apk add --no-cache \
+    git \
+    gawk \
+    linux-headers \
     build-base \
     cargo \
     rust \
     && rm -rf /var/cache/apk/*
 
+# Build firejail from source
+RUN git clone --depth 1 --branch 0.9.72 https://github.com/netblue30/firejail.git
+WORKDIR /firejail
+RUN ./configure && make && make install-strip && firejail --version
+
+# Install python dependencies
+WORKDIR /usr/src/app
+
 # Copy source code
 COPY pyproject.toml VERSION Makefile setup.py README.md ./
 COPY checker ./checker
 
-# Install python dependencies
+# Install python dependencies and checker
 RUN python -m venv /opt/checker-venv
-RUN /opt/checker-venv/bin/python -m pip install --no-cache-dir --require-virtualenv .
-RUN find /opt/checker-venv -type d -name '__pycache__' -exec rm -r {} + && \
+RUN /opt/checker-venv/bin/python -m pip install --no-cache-dir --require-virtualenv . && \
+    find /opt/checker-venv -type d -name '__pycache__' -exec rm -r {} + && \
     find /opt/checker-venv -type d -name 'tests' -exec rm -rf {} + && \
     find /opt/checker-venv -name '*.pyc' -delete && \
     find /opt/checker-venv -name '*.pyo' -delete && \
@@ -32,10 +41,14 @@ FROM python:${PYTHON_VERSION}-alpine
 WORKDIR /usr/src/app
 
 # Install additional tools
-RUN apk update && apk add --no-cache \
-    git
+RUN apk update  \
+    && apk add --no-cache \
+        git
 
-# Copy python dependencies
+# Copy firejail
+COPY --from=builder /usr/local/bin/firejail /usr/local/bin/firejail
+
+# Copy python dependencies and checker
 COPY --from=builder /opt/checker-venv /opt/checker-venv
 
 ENTRYPOINT [ "/opt/checker-venv/bin/python", "-m", "checker" ]

--- a/checker/plugins/firejail.py
+++ b/checker/plugins/firejail.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+
+from .scripts import RunScriptPlugin
+
+
+PATH = 'PATH'
+PYTHONPATH = 'PYTHONPATH'
+
+
+class SafeRunScriptPlugin(RunScriptPlugin):
+    """Plugin for running scripts in safe mode."""
+
+    name = "safe_run_script"
+
+    Args = RunScriptPlugin.Args
+
+    # TODO(uniqum): at the moment "--queit" option of firejail may stil put extra strings in the output
+    def _run(self, args: Args, *, verbose: bool = False) -> str:
+        whitelist_dir = args.origin if not args.origin.startswith('/tmp') else '~/tmp'
+        command = ['firejail',
+                   '--quiet',
+                   '--noprofile',
+                   # lock network access
+                   '--net=none',
+                   # allow access to origin dir
+                   f'--whitelist={whitelist_dir}',
+                   # hide all environment variables
+                   'env -i',
+                   # copy PATH
+                   f'{PATH}={os.environ.get(PATH, "")}',
+                   # cope PYTHONPATH
+                   f'{PYTHONPATH}={os.environ.get(PYTHONPATH, "")}',
+                   args.script if isinstance(args.script, str) else ' '.join(args.script),
+                   ]
+        run_args = RunScriptPlugin.Args(origin=args.origin, script=' '.join(command), timeout=args.timeout)
+
+        return super()._run(args=run_args, verbose=verbose)

--- a/checker/plugins/firejail.py
+++ b/checker/plugins/firejail.py
@@ -51,8 +51,6 @@ class SafeRunScriptPlugin(PluginABC):
         else:
             assert isinstance(args.script, list)
             command.extend(args.script)
-        run_args = RunScriptPlugin.Args(
-            origin=args.origin, script=" ".join(command), timeout=args.timeout
-        )
+        run_args = RunScriptPlugin.Args(origin=args.origin, script=" ".join(command), timeout=args.timeout)
 
         return RunScriptPlugin()._run(args=run_args, verbose=verbose)

--- a/checker/plugins/firejail.py
+++ b/checker/plugins/firejail.py
@@ -4,13 +4,13 @@ import os
 from pathlib import Path
 
 from .base import PluginOutput
-from .scripts import RunScriptPlugin
+from .scripts import RunScriptPlugin, PluginABC
 
 
 HOME_PATH = str(Path.home())
 
 
-class SafeRunScriptPlugin(RunScriptPlugin):
+class SafeRunScriptPlugin(PluginABC):
     """Wrapper over RunScriptPlugin to run students scripts safety.
     Plugin uses Firejail tool to create sandbox for the running process.
     He allows hide environment variables and control access to network and file system.
@@ -56,4 +56,4 @@ class SafeRunScriptPlugin(RunScriptPlugin):
             origin=args.origin, script=" ".join(command), timeout=args.timeout
         )
 
-        return super()._run(args=run_args, verbose=verbose)
+        return RunScriptPlugin()._run(args=run_args, verbose=verbose)

--- a/checker/plugins/firejail.py
+++ b/checker/plugins/firejail.py
@@ -24,7 +24,7 @@ class SafeRunScriptPlugin(RunScriptPlugin):
         allow_paths: set[str] = set()
 
     # TODO: at the moment "--queit" option of firejail may stil put extra strings in the output
-    def _run(self, args: Args, *, verbose: bool = False) -> PluginOutput:
+    def _run(self, args: Args, *, verbose: bool = False) -> PluginOutput:  # type: ignore[override]
         command = ["firejail", "--quiet", "--noprofile"]
         # lock network access
         if args.lock_network:

--- a/checker/plugins/firejail.py
+++ b/checker/plugins/firejail.py
@@ -26,8 +26,8 @@ class SafeRunScriptPlugin(PluginABC):
         script: Union[str, list[str]]  # as pydantic does not support | in older python versions
         timeout: Union[float, None] = None  # as pydantic does not support | in older python versions
 
-        env_whitelist: set[str] = set()
-        paths_whitelist: set[str] = set()
+        env_whitelist: list[str] = list()
+        paths_whitelist: list[str] = list()
         lock_network: bool = True
         allow_fallback: bool = False
 
@@ -40,7 +40,7 @@ class SafeRunScriptPlugin(PluginABC):
         if result.returncode != 0:
             if args.allow_fallback:
                 # fallback to RunScriptPlugin
-                run_args = RunScriptPlugin.Args(origin=args.origin, script=args.script, timeout=args.timeout)
+                run_args = RunScriptPlugin.Args(origin=args.origin, script=args.script, timeout=args.timeout, env_whitelist=env_whitelist)
                 output = RunScriptPlugin()._run(args=run_args, verbose=verbose)
                 if verbose:
                     output.output = f"Firejail is not installed. Fallback to RunScriptPlugin.\n{output.output}"
@@ -85,5 +85,5 @@ class SafeRunScriptPlugin(PluginABC):
             assert False, "Now Reachable"
 
         # Will use RunScriptPlugin to run Firejail+command
-        run_args = RunScriptPlugin.Args(origin=args.origin, script=run_command, timeout=args.timeout)
+        run_args = RunScriptPlugin.Args(origin=args.origin, script=run_command, timeout=args.timeout, env_whitelist=None)
         return RunScriptPlugin()._run(args=run_args, verbose=verbose)

--- a/checker/plugins/firejail.py
+++ b/checker/plugins/firejail.py
@@ -1,39 +1,58 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from .scripts import RunScriptPlugin
 
 
-PATH = 'PATH'
-PYTHONPATH = 'PYTHONPATH'
+HOME_PATH = str(Path.home())
 
 
 class SafeRunScriptPlugin(RunScriptPlugin):
-    """Plugin for running scripts in safe mode."""
+    """Wrapper over RunScriptPlugin to run students scripts safety.
+    Plugin uses Firejail tool to create sandbox for the running process.
+    He allows hide environment variables and control access to network and file system.
+    """
 
     name = "safe_run_script"
 
-    Args = RunScriptPlugin.Args
+    class Args(RunScriptPlugin.Args):
+        allow_envs: set[str] = set()
+        lock_network: bool = True
+        allow_paths: set[str] = set()
 
-    # TODO(uniqum): at the moment "--queit" option of firejail may stil put extra strings in the output
+    # TODO: at the moment "--queit" option of firejail may stil put extra strings in the output
     def _run(self, args: Args, *, verbose: bool = False) -> str:
-        whitelist_dir = args.origin if not args.origin.startswith('/tmp') else '~/tmp'
-        command = ['firejail',
-                   '--quiet',
-                   '--noprofile',
-                   # lock network access
-                   '--net=none',
-                   # allow access to origin dir
-                   f'--whitelist={whitelist_dir}',
-                   # hide all environment variables
-                   'env -i',
-                   # copy PATH
-                   f'{PATH}={os.environ.get(PATH, "")}',
-                   # cope PYTHONPATH
-                   f'{PYTHONPATH}={os.environ.get(PYTHONPATH, "")}',
-                   args.script if isinstance(args.script, str) else ' '.join(args.script),
-                   ]
-        run_args = RunScriptPlugin.Args(origin=args.origin, script=' '.join(command), timeout=args.timeout)
+        command = ["firejail", "--quiet", "--noprofile"]
+        # lock network access
+        if args.lock_network:
+            command.append("--net=none")
+        # collect all allow paths
+        allow_paths = args.allow_paths.copy()
+        allow_paths.add(args.origin)
+        # a bit tricky but if paths is only /tmp add ~/tmp instead of it
+        if "/tmp" in allow_paths and len(allow_paths) == 1:
+            allow_paths.add("~/tmp")
+        # remove /tmp from paths as it causes error inside of Firejail
+        if "/tmp" in allow_paths:
+            allow_paths.remove("/tmp")
+        # replace ~ by the full home path
+        for path in allow_paths:
+            full_path = path if not path.startswith("~") else HOME_PATH + path[1:]
+            # allow access to origin dir
+            command.append(f"--whitelist={full_path}")
+        # hide all environment variables
+        command.append("env -i")
+        for env in args.allow_envs:
+            command.append(f'{env}="{os.environ.get(env, "")}"')
+        if isinstance(args.script, str):
+            command.append(args.script)
+        else:
+            assert isinstance(args.script, list)
+            command.extend(args.script)
+        run_args = RunScriptPlugin.Args(
+            origin=args.origin, script=" ".join(command), timeout=args.timeout
+        )
 
         return super()._run(args=run_args, verbose=verbose)

--- a/checker/plugins/firejail.py
+++ b/checker/plugins/firejail.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 from .base import PluginOutput
-from .scripts import RunScriptPlugin, PluginABC
+from .scripts import PluginABC, RunScriptPlugin
 
 
 HOME_PATH = str(Path.home())

--- a/checker/plugins/firejail.py
+++ b/checker/plugins/firejail.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from .base import PluginOutput
 from .scripts import RunScriptPlugin
 
 
@@ -23,7 +24,7 @@ class SafeRunScriptPlugin(RunScriptPlugin):
         allow_paths: set[str] = set()
 
     # TODO: at the moment "--queit" option of firejail may stil put extra strings in the output
-    def _run(self, args: Args, *, verbose: bool = False) -> str:
+    def _run(self, args: Args, *, verbose: bool = False) -> PluginOutput:
         command = ["firejail", "--quiet", "--noprofile"]
         # lock network access
         if args.lock_network:

--- a/checker/plugins/firejail.py
+++ b/checker/plugins/firejail.py
@@ -23,7 +23,6 @@ class SafeRunScriptPlugin(PluginABC):
         lock_network: bool = True
         allow_paths: set[str] = set()
 
-    # TODO: at the moment "--queit" option of firejail may stil put extra strings in the output
     def _run(self, args: Args, *, verbose: bool = False) -> PluginOutput:  # type: ignore[override]
         command = ["firejail", "--quiet", "--noprofile"]
         # lock network access

--- a/checker/plugins/firejail.py
+++ b/checker/plugins/firejail.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from pathlib import Path
+from typing import Union
 
 from .base import PluginOutput
 from .scripts import PluginABC, RunScriptPlugin
-
+from ..exceptions import PluginExecutionFailed
 
 HOME_PATH = str(Path.home())
 
@@ -13,28 +15,51 @@ HOME_PATH = str(Path.home())
 class SafeRunScriptPlugin(PluginABC):
     """Wrapper over RunScriptPlugin to run students scripts safety.
     Plugin uses Firejail tool to create sandbox for the running process.
-    He allows hide environment variables and control access to network and file system.
+    It allows hide environment variables and control access to network and file system.
+    If `allow_fallback=True` then if Firejail is not installed, it will fallback to RunScriptPlugin.
     """
 
     name = "safe_run_script"
 
-    class Args(RunScriptPlugin.Args):
+    class Args(PluginABC.Args):
+        origin: str
+        script: Union[str, list[str]]  # as pydantic does not support | in older python versions
+        timeout: Union[float, None] = None  # as pydantic does not support | in older python versions
+
         allow_envs: set[str] = set()
         lock_network: bool = True
         allow_paths: set[str] = set()
+        allow_fallback: bool = False
 
     def _run(self, args: Args, *, verbose: bool = False) -> PluginOutput:  # type: ignore[override]
+        # test if firejail script is available
+        # TODO: test fallback
+        result = subprocess.run(["firejail", "--version"], capture_output=True)
+        if result.returncode != 0:
+            if args.allow_fallback:
+                # fallback to RunScriptPlugin
+                run_args = RunScriptPlugin.Args(origin=args.origin, script=args.script, timeout=args.timeout)
+                output = RunScriptPlugin()._run(args=run_args, verbose=verbose)
+                if verbose:
+                    output.output = f"Firejail is not installed. Fallback to RunScriptPlugin.\n{output.output}"
+                return output
+            else:
+                # error
+                raise PluginExecutionFailed("Firejail is not installed", output=result.stderr.decode("utf-8"))
+
+        # Construct firejail command
         command = ["firejail", "--quiet", "--noprofile"]
+
         # lock network access
         if args.lock_network:
             command.append("--net=none")
-        # collect all allow paths
-        allow_paths = args.allow_paths.copy()
-        allow_paths.add(args.origin)
+
+        # Collect all allow paths
+        allow_paths = {*args.allow_paths, args.origin}
         # a bit tricky but if paths is only /tmp add ~/tmp instead of it
         if "/tmp" in allow_paths and len(allow_paths) == 1:
             allow_paths.add("~/tmp")
-        # remove /tmp from paths as it causes error inside of Firejail
+        # remove /tmp from paths as it causes error inside Firejail
         if "/tmp" in allow_paths:
             allow_paths.remove("/tmp")
         # replace ~ by the full home path
@@ -42,15 +67,19 @@ class SafeRunScriptPlugin(PluginABC):
             full_path = path if not path.startswith("~") else HOME_PATH + path[1:]
             # allow access to origin dir
             command.append(f"--whitelist={full_path}")
-        # hide all environment variables
+
+        # Hide all environment variables except allowed
         command.append("env -i")
         for env in args.allow_envs:
             command.append(f'{env}="{os.environ.get(env, "")}"')
+
+        # create actual command
         if isinstance(args.script, str):
-            command.append(args.script)
+            command = " ".join(command) + " " + args.script
         else:
             assert isinstance(args.script, list)
             command.extend(args.script)
-        run_args = RunScriptPlugin.Args(origin=args.origin, script=" ".join(command), timeout=args.timeout)
 
+        # Will use RunScriptPlugin to run Firejail+command
+        run_args = RunScriptPlugin.Args(origin=args.origin, script=command, timeout=args.timeout)
         return RunScriptPlugin()._run(args=run_args, verbose=verbose)

--- a/checker/plugins/firejail.py
+++ b/checker/plugins/firejail.py
@@ -40,7 +40,9 @@ class SafeRunScriptPlugin(PluginABC):
         if result.returncode != 0:
             if args.allow_fallback:
                 # fallback to RunScriptPlugin
-                run_args = RunScriptPlugin.Args(origin=args.origin, script=args.script, timeout=args.timeout, env_whitelist=env_whitelist)
+                run_args = RunScriptPlugin.Args(
+                    origin=args.origin, script=args.script, timeout=args.timeout, env_whitelist=args.env_whitelist
+                )
                 output = RunScriptPlugin()._run(args=run_args, verbose=verbose)
                 if verbose:
                     output.output = f"Firejail is not installed. Fallback to RunScriptPlugin.\n{output.output}"
@@ -85,5 +87,7 @@ class SafeRunScriptPlugin(PluginABC):
             assert False, "Now Reachable"
 
         # Will use RunScriptPlugin to run Firejail+command
-        run_args = RunScriptPlugin.Args(origin=args.origin, script=run_command, timeout=args.timeout, env_whitelist=None)
+        run_args = RunScriptPlugin.Args(
+            origin=args.origin, script=run_command, timeout=args.timeout, env_whitelist=None
+        )
         return RunScriptPlugin()._run(args=run_args, verbose=verbose)

--- a/checker/plugins/scripts.py
+++ b/checker/plugins/scripts.py
@@ -23,6 +23,9 @@ class RunScriptPlugin(PluginABC):
         def set_up_env_sandbox() -> None:  # pragma: nocover
             import os
 
+            if args.env_whitelist is None:
+                return
+
             env = os.environ.copy()
             os.environ.clear()
             for variable in args.env_whitelist:

--- a/checker/plugins/scripts.py
+++ b/checker/plugins/scripts.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Union
 
-from pydantic import Field
-
 from ..exceptions import PluginExecutionFailed
 from .base import PluginABC, PluginOutput
 
@@ -17,19 +15,9 @@ class RunScriptPlugin(PluginABC):
         origin: str
         script: Union[str, list[str]]  # as pydantic does not support | in older python versions
         timeout: Union[float, None] = None  # as pydantic does not support | in older python versions
-        isolate: bool = False
-        env_whitelist: list[str] = Field(default_factory=lambda: ["PATH"])
 
     def _run(self, args: Args, *, verbose: bool = False) -> PluginOutput:  # type: ignore[override]
         import subprocess
-
-        def set_up_env_sandbox() -> None:  # pragma: nocover
-            import os
-
-            env = os.environ.copy()
-            os.environ.clear()
-            for variable in args.env_whitelist:
-                os.environ[variable] = env[variable]
 
         try:
             result = subprocess.run(
@@ -40,7 +28,6 @@ class RunScriptPlugin(PluginABC):
                 check=True,  # raise CalledProcessError if return code is non-zero
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,  # merge stderr & stdout to single output
-                preexec_fn=set_up_env_sandbox,
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             output = e.output or ""

--- a/checker/plugins/scripts.py
+++ b/checker/plugins/scripts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Union
+from typing import Optional, Union
 
 from ..exceptions import PluginExecutionFailed
 from .base import PluginABC, PluginOutput
@@ -15,9 +15,18 @@ class RunScriptPlugin(PluginABC):
         origin: str
         script: Union[str, list[str]]  # as pydantic does not support | in older python versions
         timeout: Union[float, None] = None  # as pydantic does not support | in older python versions
+        env_whitelist: Optional[list[str]] = None
 
     def _run(self, args: Args, *, verbose: bool = False) -> PluginOutput:  # type: ignore[override]
         import subprocess
+
+        def set_up_env_sandbox() -> None:  # pragma: nocover
+            import os
+
+            env = os.environ.copy()
+            os.environ.clear()
+            for variable in args.env_whitelist:
+                os.environ[variable] = env[variable]
 
         try:
             result = subprocess.run(
@@ -28,6 +37,7 @@ class RunScriptPlugin(PluginABC):
                 check=True,  # raise CalledProcessError if return code is non-zero
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,  # merge stderr & stdout to single output
+                preexec_fn=set_up_env_sandbox if args.env_whitelist else None,
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             output = e.output or ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,14 @@ def generate_file_structure(
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption(
+        "--skip-firejail",
+        action="store_true",
+        dest="skip_firejail",
+        default=False,
+        help="skip firejail tests",
+    )
+
+    parser.addoption(
         "--skip-integration",
         action="store_true",
         dest="skip_integration",
@@ -86,6 +94,8 @@ def pytest_collection_modifyitems(
     config: pytest.Config,
     items: list[pytest.Item],
 ) -> None:
+    skip_firejail = pytest.mark.skip(reason="--skip-firejail option was provided")
+
     skip_integration = pytest.mark.skip(reason="--skip-integration option was provided")
     skip_unit = pytest.mark.skip(reason="--skip-unit option was provided")
     skip_doctest = pytest.mark.skip(reason="--skip-doctest option was provided")
@@ -93,6 +103,9 @@ def pytest_collection_modifyitems(
     for item in items:
         if isinstance(item, pytest.DoctestItem):
             item.add_marker(skip_doctest)
+        elif "firejail" in item.keywords:
+            if config.getoption("--skip-firejail"):
+                item.add_marker(skip_firejail)
         elif "integration" in item.keywords:
             if config.getoption("--skip-integration"):
                 item.add_marker(skip_integration)

--- a/tests/plugins/test_firejail.py
+++ b/tests/plugins/test_firejail.py
@@ -7,38 +7,47 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from checker.plugins.firejail import PATH
-from checker.plugins.firejail import PYTHONPATH
 from checker.plugins.firejail import SafeRunScriptPlugin
 from checker.exceptions import PluginExecutionFailed
 
 
 PATTERN_ENV = re.compile(r"(?P<name>\S+)=.*")
+PATH = "PATH"
+PYTHONPATH = "PYTHONPATH"
 
 
 class TestSafeRunScriptPlugin:
-
-    @pytest.mark.parametrize("parameters, expected_exception", [
-        ({"origin": "/tmp/123", "script": "echo Hello"}, None),
-        ({"origin": "/tmp/123", "script": 123}, ValidationError),
-        ({"origin": "/tmp/123", "script": ["echo", "Hello"]}, None),
-        ({"origin": "/tmp/123", "script": "echo Hello", "timeout": 10}, None),
-    ])
-    def test_plugin_args(self, parameters: dict[str, Any], expected_exception: Exception | None) -> None:
+    @pytest.mark.parametrize(
+        "parameters, expected_exception",
+        [
+            ({"origin": "/tmp/123", "script": "echo Hello"}, None),
+            ({"origin": "/tmp/123", "script": 123}, ValidationError),
+            ({"origin": "/tmp/123", "script": ["echo", "Hello"]}, None),
+            ({"origin": "/tmp/123", "script": "echo Hello", "timeout": 10}, None),
+        ],
+    )
+    def test_plugin_args(
+        self, parameters: dict[str, Any], expected_exception: Exception | None
+    ) -> None:
         if expected_exception:
             with pytest.raises(expected_exception):
                 SafeRunScriptPlugin.Args(**parameters)
         else:
             SafeRunScriptPlugin.Args(**parameters)
 
-    @pytest.mark.parametrize("script, output, expected_exception", [
-        ("echo Hello", "Hello", None),
-        ("sleep 0.1", "", None),
-        ("true", "", None),
-        ("false", "", PluginExecutionFailed),
-        ("echo Hello && false", "Hello", PluginExecutionFailed),
-    ])
-    def test_run_script(self, script: str, output: str, expected_exception: Exception | None) -> None:
+    @pytest.mark.parametrize(
+        "script, output, expected_exception",
+        [
+            ("echo Hello", "Hello", None),
+            ("sleep 0.1", "", None),
+            ("true", "", None),
+            ("false", "", PluginExecutionFailed),
+            ("echo Hello && false", "Hello", PluginExecutionFailed),
+        ],
+    )
+    def test_run_script(
+        self, script: str, output: str, expected_exception: Exception | None
+    ) -> None:
         plugin = SafeRunScriptPlugin()
         args = SafeRunScriptPlugin.Args(origin="/tmp", script=script)
 
@@ -50,13 +59,18 @@ class TestSafeRunScriptPlugin:
             res = plugin._run(args)
             assert res.output.strip() == output
 
-    @pytest.mark.parametrize("script, timeout, expected_exception", [
-        ("echo Hello", 10, None),
-        ("sleep 0.5", 1, None),
-        ("sleep 1", None, None),
-        ("sleep 2", 1, PluginExecutionFailed),
-    ])
-    def test_timeout(self, script: str, timeout: float, expected_exception: Exception | None) -> None:
+    @pytest.mark.parametrize(
+        "script, timeout, expected_exception",
+        [
+            ("echo Hello", 10, None),
+            ("sleep 0.5", 1, None),
+            ("sleep 1", None, None),
+            ("sleep 2", 1, PluginExecutionFailed),
+        ],
+    )
+    def test_timeout(
+        self, script: str, timeout: float, expected_exception: Exception | None
+    ) -> None:
         # TODO: check if timeout float
         plugin = SafeRunScriptPlugin()
         args = SafeRunScriptPlugin.Args(origin="/tmp", script=script, timeout=timeout)
@@ -67,9 +81,19 @@ class TestSafeRunScriptPlugin:
         else:
             plugin._run(args)
 
-    def test_hide_evns(self) -> None:
+    @pytest.mark.parametrize(
+        "allow_envs",
+        [
+            ([]),
+            ([PATH]),
+            ([PATH, PYTHONPATH]),
+        ],
+    )
+    def test_hide_evns(self, allow_envs: list[str]) -> None:
         plugin = SafeRunScriptPlugin()
-        args = SafeRunScriptPlugin.Args(origin="/tmp", script="printenv")
+        args = SafeRunScriptPlugin.Args(
+            origin="/tmp", script="printenv", allow_envs=allow_envs
+        )
 
         res_lines = [line.strip() for line in plugin._run(args).output.splitlines()]
         envs: list[str] = []
@@ -79,45 +103,94 @@ class TestSafeRunScriptPlugin:
                 envs.append(match.group("name"))
 
         # check if environment has only two items: PATH and PYTHONPATH
-        assert len(envs) == 2
-        assert PATH in envs
-        assert PYTHONPATH in envs
+        assert len(envs) == len(allow_envs)
+        for env in envs:
+            assert env in allow_envs
 
-    @pytest.mark.parametrize("query", [
-        ("curl -i -X GET https://www.example.org"),
-        ("curl --user daniel:secret ftp://example.com/download"),
-    ])
-    def test_network_access(self, query: str) -> None:
+    @pytest.mark.parametrize(
+        "query",
+        [
+            ("curl -i -X GET https://www.example.org"),
+            ("curl --user daniel:secret ftp://example.com/download"),
+        ],
+    )
+    def test_allow_network_access(self, query: str) -> None:
+        # TODO: have to mock network and check if lock_network = False allows access to the Internet
         plugin = SafeRunScriptPlugin()
-        args = SafeRunScriptPlugin.Args(origin="/tmp", script=query)
+        args = SafeRunScriptPlugin.Args(origin="/tmp", script=query, lock_network=True)
 
         with pytest.raises(PluginExecutionFailed):
             plugin._run(args)
 
-    @pytest.mark.parametrize("origin, access_file, expected_exception", [
-        ("/tmp", "/tmp/tmp.txt", None),
-        ("/tmp", Path.home().joinpath("tmp", "tmp.txt"), None),  # this is a trick!!! origin /tmp is replaced by ~/tmp
-        ("/tmp", Path.home().joinpath("tmp.txt"), PluginExecutionFailed),
-        ("/tmp", Path.home().joinpath("not_tmp", "tmp.txt"), PluginExecutionFailed),
-        (Path.home(), Path.home().joinpath("tmp.txt"), None),
-        (Path.home(), Path.home().joinpath("tmp", "tmp.txt"), None),
-        (Path.home(), Path.home().joinpath("not_tmp", "tmp.txt"), None),
-        (Path.home().joinpath("tmp"), Path.home().joinpath("tmp", "tmp.txt"), None),
-        (Path.home().joinpath("tmp"), Path.home().joinpath("tmp.txt"), PluginExecutionFailed),
-        (Path.home().joinpath("tmp"), Path.home().joinpath("not_tmp", "tmp.txt"), PluginExecutionFailed),
-    ])
-    def test_file_system_access(self,
-                                origin: Path | str,
-                                access_file: Path | str,
-                                expected_exception: Exception | None) -> None:
-        access_file_path = Path(access_file)
+    @pytest.mark.parametrize(
+        "origin, allow_paths, access_file, expected_exception",
+        [
+            ("/tmp", [], Path("/tmp/tmp.txt"), None),
+            (
+                "/tmp",
+                [],
+                Path.home().joinpath("tmp", "tmp.txt"),
+                None,
+            ),  # this is a trick!!! origin /tmp is replaced by ~/tmp
+            ("/tmp", [], Path.home().joinpath("tmp.txt"), PluginExecutionFailed),
+            ("/tmp", ["~"], Path.home().joinpath("tmp.txt"), None),
+            ("~", [], Path.home().joinpath("tmp.txt"), None),
+            (
+                "/tmp",
+                [],
+                Path.home().joinpath("not_tmp", "tmp.txt"),
+                PluginExecutionFailed,
+            ),
+            ("/tmp", ["~/not_tmp"], Path.home().joinpath("not_tmp", "tmp.txt"), None),
+            ("~/not_tmp", [], Path.home().joinpath("not_tmp", "tmp.txt"), None),
+            ("~", [], Path.home().joinpath("tmp.txt"), None),
+            ("~/not_tmp", [], Path.home().joinpath("tmp.txt"), PluginExecutionFailed),
+            ("~/not_tmp", ["~"], Path.home().joinpath("tmp.txt"), None),
+            ("~", [], Path.home().joinpath("tmp", "tmp.txt"), None),
+            ("~/not_tmp", ["~"], Path.home().joinpath("tmp", "tmp.txt"), None),
+            ("~", [], Path.home().joinpath("not_tmp", "tmp.txt"), None),
+            ("~/tmp", [], Path.home().joinpath("tmp", "tmp.txt"), None),
+            ("~/not_tmp", ["~/tmp"], Path.home().joinpath("tmp", "tmp.txt"), None),
+            ("~/tmp", [], Path.home().joinpath("tmp.txt"), PluginExecutionFailed),
+            (
+                "~/not_tmp",
+                ["~/tmp"],
+                Path.home().joinpath("tmp.txt"),
+                PluginExecutionFailed,
+            ),
+            (
+                "~/tmp",
+                [],
+                Path.home().joinpath("not_tmp", "tmp.txt"),
+                PluginExecutionFailed,
+            ),
+            (
+                "/tmp",
+                ["~/tmp"],
+                Path.home().joinpath("not_tmp", "tmp.txt"),
+                PluginExecutionFailed,
+            ),
+        ],
+    )
+    def test_file_system_access(
+        self,
+        origin: str,
+        allow_paths: list[str],
+        access_file: Path,
+        expected_exception: Exception | None,
+    ) -> None:
+        access_file_path = access_file
         access_file_path.parent.mkdir(parents=True, exist_ok=True)
         access_file_path.touch()
 
         Path(origin).mkdir(parents=True, exist_ok=True)
 
         plugin = SafeRunScriptPlugin()
-        args = SafeRunScriptPlugin.Args(origin=str(origin), script=f'cat {str(access_file)}')
+        args = SafeRunScriptPlugin.Args(
+            origin=str(origin),
+            allow_paths=allow_paths,
+            script=f"cat {str(access_file)}",
+        )
 
         if expected_exception:
             with pytest.raises(expected_exception):

--- a/tests/plugins/test_firejail.py
+++ b/tests/plugins/test_firejail.py
@@ -28,6 +28,7 @@ def in_home(path: str) -> Path:
     return HOME.joinpath(path)
 
 
+@pytest.mark.firejail
 class TestSafeRunScriptPlugin:
     @pytest.mark.parametrize(
         "parameters, expected_exception",

--- a/tests/plugins/test_firejail.py
+++ b/tests/plugins/test_firejail.py
@@ -8,8 +8,8 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from checker.plugins.firejail import SafeRunScriptPlugin
 from checker.exceptions import PluginExecutionFailed
+from checker.plugins.firejail import SafeRunScriptPlugin
 
 
 PATTERN_ENV = re.compile(r"(?P<name>\S+)=.*")

--- a/tests/plugins/test_firejail.py
+++ b/tests/plugins/test_firejail.py
@@ -196,9 +196,9 @@ class TestSafeRunScriptPlugin:
         def _generate_random_content() -> str:
             return "".join([RANDOM_LINES[randrange(0, len(RANDOM_LINES))] for _ in range(0, randrange(0, 100))])
 
-        tmp_dir = in_home('tmp')
+        tmp_dir = in_home("tmp")
         tmp_dir.mkdir(parents=True, exist_ok=True)
-        file_path = tmp_dir.joinpath('tmp.txt')
+        file_path = tmp_dir.joinpath("tmp.txt")
         file_content = test_file_content if test_file_content != RANDOM_CONTENT else _generate_random_content()
         with open(file_path, "w") as f:
             f.write(file_content)

--- a/tests/plugins/test_firejail.py
+++ b/tests/plugins/test_firejail.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from checker.plugins.firejail import PATH
+from checker.plugins.firejail import PYTHONPATH
+from checker.plugins.firejail import SafeRunScriptPlugin
+from checker.exceptions import PluginExecutionFailed
+
+
+PATTERN_ENV = re.compile(r"(?P<name>\S+)=.*")
+
+
+class TestSafeRunScriptPlugin:
+
+    @pytest.mark.parametrize("parameters, expected_exception", [
+        ({"origin": "/tmp/123", "script": "echo Hello"}, None),
+        ({"origin": "/tmp/123", "script": 123}, ValidationError),
+        ({"origin": "/tmp/123", "script": ["echo", "Hello"]}, None),
+        ({"origin": "/tmp/123", "script": "echo Hello", "timeout": 10}, None),
+    ])
+    def test_plugin_args(self, parameters: dict[str, Any], expected_exception: Exception | None) -> None:
+        if expected_exception:
+            with pytest.raises(expected_exception):
+                SafeRunScriptPlugin.Args(**parameters)
+        else:
+            SafeRunScriptPlugin.Args(**parameters)
+
+    @pytest.mark.parametrize("script, output, expected_exception", [
+        ("echo Hello", "Hello", None),
+        ("sleep 0.1", "", None),
+        ("true", "", None),
+        ("false", "", PluginExecutionFailed),
+        ("echo Hello && false", "Hello", PluginExecutionFailed),
+    ])
+    def test_run_script(self, script: str, output: str, expected_exception: Exception | None) -> None:
+        plugin = SafeRunScriptPlugin()
+        args = SafeRunScriptPlugin.Args(origin="/tmp", script=script)
+
+        if expected_exception:
+            with pytest.raises(expected_exception) as exc_info:
+                plugin._run(args)
+            assert output in exc_info.value.output
+        else:
+            res = plugin._run(args)
+            assert res.output.strip() == output
+
+    @pytest.mark.parametrize("script, timeout, expected_exception", [
+        ("echo Hello", 10, None),
+        ("sleep 0.5", 1, None),
+        ("sleep 1", None, None),
+        ("sleep 2", 1, PluginExecutionFailed),
+    ])
+    def test_timeout(self, script: str, timeout: float, expected_exception: Exception | None) -> None:
+        # TODO: check if timeout float
+        plugin = SafeRunScriptPlugin()
+        args = SafeRunScriptPlugin.Args(origin="/tmp", script=script, timeout=timeout)
+
+        if expected_exception:
+            with pytest.raises(expected_exception):
+                plugin._run(args)
+        else:
+            plugin._run(args)
+
+    def test_hide_evns(self) -> None:
+        plugin = SafeRunScriptPlugin()
+        args = SafeRunScriptPlugin.Args(origin="/tmp", script="printenv")
+
+        res_lines = [line.strip() for line in plugin._run(args).output.splitlines()]
+        envs: list[str] = []
+        for line in res_lines:
+            match = PATTERN_ENV.match(line)
+            if match and not match.group("name").startswith("-"):
+                envs.append(match.group("name"))
+
+        # check if environment has only two items: PATH and PYTHONPATH
+        assert len(envs) == 2
+        assert PATH in envs
+        assert PYTHONPATH in envs
+
+    @pytest.mark.parametrize("query", [
+        ("curl -i -X GET https://www.example.org"),
+        ("curl --user daniel:secret ftp://example.com/download"),
+    ])
+    def test_network_access(self, query: str) -> None:
+        plugin = SafeRunScriptPlugin()
+        args = SafeRunScriptPlugin.Args(origin="/tmp", script=query)
+
+        with pytest.raises(PluginExecutionFailed):
+            plugin._run(args)
+
+    @pytest.mark.parametrize("origin, access_file, expected_exception", [
+        ("/tmp", "/tmp/tmp.txt", None),
+        ("/tmp", Path.home().joinpath("tmp", "tmp.txt"), None),  # this is a trick!!! origin /tmp is replaced by ~/tmp
+        ("/tmp", Path.home().joinpath("tmp.txt"), PluginExecutionFailed),
+        ("/tmp", Path.home().joinpath("not_tmp", "tmp.txt"), PluginExecutionFailed),
+        (Path.home(), Path.home().joinpath("tmp.txt"), None),
+        (Path.home(), Path.home().joinpath("tmp", "tmp.txt"), None),
+        (Path.home(), Path.home().joinpath("not_tmp", "tmp.txt"), None),
+        (Path.home().joinpath("tmp"), Path.home().joinpath("tmp", "tmp.txt"), None),
+        (Path.home().joinpath("tmp"), Path.home().joinpath("tmp.txt"), PluginExecutionFailed),
+        (Path.home().joinpath("tmp"), Path.home().joinpath("not_tmp", "tmp.txt"), PluginExecutionFailed),
+    ])
+    def test_file_system_access(self,
+                                origin: Path | str,
+                                access_file: Path | str,
+                                expected_exception: Exception | None) -> None:
+        access_file_path = Path(access_file)
+        access_file_path.parent.mkdir(parents=True, exist_ok=True)
+        access_file_path.touch()
+
+        Path(origin).mkdir(parents=True, exist_ok=True)
+
+        plugin = SafeRunScriptPlugin()
+        args = SafeRunScriptPlugin.Args(origin=str(origin), script=f'cat {str(access_file)}')
+
+        if expected_exception:
+            with pytest.raises(expected_exception):
+                plugin._run(args)
+        else:
+            plugin._run(args)
+
+        access_file_path.unlink()

--- a/tests/plugins/test_scripts.py
+++ b/tests/plugins/test_scripts.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError

--- a/tests/plugins/test_scripts.py
+++ b/tests/plugins/test_scripts.py
@@ -83,22 +83,3 @@ class TestRunScriptPlugin:
                 plugin._run(args)
         else:
             plugin._run(args)
-
-    @pytest.mark.parametrize(
-        "script, env_whitelist, mocked_env",
-        [
-            ("env", ["CUSTOM_VAR"], {"FILTERED_ONE": "1", "CUSTOM_VAR": "test_value"}),
-            # TODO: expand this test
-        ],
-    )
-    def test_run_with_environment_variable(
-        self, script: str, env_whitelist: list[str], mocked_env: dict[str, str]
-    ) -> None:
-        plugin = RunScriptPlugin()
-        args = RunScriptPlugin.Args(origin="/tmp", script=script, env_whitelist=env_whitelist)
-
-        with patch.dict("os.environ", mocked_env, clear=True):
-            result = plugin._run(args)
-        assert "CUSTOM_VAR" in result.output
-        assert mocked_env["CUSTOM_VAR"] in result.output
-        assert "FILTERED_ONE" not in result.output


### PR DESCRIPTION
## Description

Add plugin for safe execution of students tasks.
Firejail tool is used to make sandbox.

## Motivation and Context

Students code may try to make any changes which can damage the system or steal such secret things as tokens or credentials  saved as environment variables.

This plugin intended to make runing of students scripts safety:

1. Hide all environment variables except of given.
2. Lock access to the Internet except of local sockets.
3. Prevent access to the file system except of givel folders and files.

Related to 
Closes https://github.com/manytask/checker/issues/49

## Contribution Checklist

- [x] I have read and agreed on the [CONTRIBUTING](../CONTRIBUTING.md) and [CODE OF CONDUCT](../CODE_OF_CONDUCT.md) documents.
- [x] I have run linters, type checks, import sorting and tests locally.
- [x] I have added comments to code in hard-to-understand areas.
- [x] I have added 100% coverage tests for the new code (or aren't needed).
- [ ] I have added docs for the new code (or aren't needed).
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) title: `tag(scope): description`. 
