### PR TITLE
feat: templates - `search`, `create` or `search_or_create`

### DIFF
--- a/checker/__main__.py
+++ b/checker/__main__.py
@@ -91,7 +91,6 @@ def validate(
             course,
             checker_config.structure,
             checker_config.export,
-            root,
             verbose=True,
             dry_run=True,
         )
@@ -190,7 +189,6 @@ def check(
         course,
         checker_config.structure,
         checker_config.export,
-        root,
         verbose=True,
         cleanup=not no_clean,
         dry_run=dry_run,
@@ -280,7 +278,6 @@ def grade(
         course,
         checker_config.structure,
         checker_config.export,
-        root,
         verbose=False,
         cleanup=not no_clean,
         dry_run=dry_run,
@@ -338,7 +335,6 @@ def export(
         course,
         checker_config.structure,
         checker_config.export,
-        reference_root,
         verbose=True,
         dry_run=dry_run,
     )

--- a/checker/__main__.py
+++ b/checker/__main__.py
@@ -8,7 +8,7 @@ import click
 
 from .configs import CheckerConfig, CheckerSubConfig, DeadlinesConfig
 from .course import Course, FileSystemTask
-from .exceptions import BadConfig, TestingError
+from .exceptions import CheckerValidationError, TestingError
 from .exporter import Exporter
 from .tester import Tester
 from .utils import print_ascii_tag, print_info
@@ -69,7 +69,7 @@ def validate(
     try:
         checker_config = CheckerConfig.from_yaml(ctx.obj["course_config_path"])
         deadlines_config = DeadlinesConfig.from_yaml(ctx.obj["deadlines_config_path"])
-    except BadConfig as e:
+    except CheckerValidationError as e:
         print_info("Configuration Failed", color="red")
         print_info(e)
         exit(1)
@@ -79,7 +79,7 @@ def validate(
     try:
         course = Course(deadlines_config, root)
         course.validate()
-    except BadConfig as e:
+    except CheckerValidationError as e:
         print_info("Course Validation Failed", color="red")
         print_info(e)
         exit(1)
@@ -95,7 +95,7 @@ def validate(
             dry_run=True,
         )
         exporter.validate()
-    except BadConfig as e:
+    except CheckerValidationError as e:
         print_info("Exporter Validation Failed", color="red")
         print_info(e)
         exit(1)
@@ -105,7 +105,7 @@ def validate(
     try:
         tester = Tester(course, checker_config, verbose=verbose)
         tester.validate()
-    except BadConfig as e:
+    except CheckerValidationError as e:
         print_info("Tester Validation Failed", color="red")
         print_info(e)
         exit(1)

--- a/checker/configs/checker.py
+++ b/checker/configs/checker.py
@@ -41,8 +41,35 @@ class CheckerParametersConfig(RootModel[dict[str, TParamType]]):
 
 class CheckerExportConfig(CustomBaseModel):
     class TemplateType(Enum):
+        """Template type for export for each task.
+
+        :ivar SEARCH: search for files/folder with name `some_file.template` and override `some_file` with it.
+            If `some_file.template` is empty file/folder it will delete `some_file`.
+            For ALL `some_file.template` files original `some_file` HAVE TO exist.
+            At least one `some_file.template` HAVE TO exist for each task.
+        :ivar CREATE: for all files in the repo search for template comments and delete all code between them.
+            For example:
+            ```python
+            a = 1
+            # TEMPLATE START
+            a = 2
+            # TEMPLATE END
+            b = 3
+            ```
+            will be converted to:
+            ```python
+            a = 1
+            # TODO: Your code
+            b = 3
+            ```
+            Delete file if it is empty after template comments deletion.
+            Each task HAVE to contain at least one template comment pair.
+        :ivar SEARCH_OR_CREATE: try to search for files/folder with name `some_file.template`
+            if not found try to create it using template comments.
+        """
         SEARCH = "search"
         CREATE = "create"
+        SEARCH_OR_CREATE = "search_or_create"
 
     destination: AnyUrl
     default_branch: str = "main"

--- a/checker/configs/checker.py
+++ b/checker/configs/checker.py
@@ -67,6 +67,7 @@ class CheckerExportConfig(CustomBaseModel):
         :ivar SEARCH_OR_CREATE: try to search for files/folder with name `some_file.template`
             if not found try to create it using template comments.
         """
+
         SEARCH = "search"
         CREATE = "create"
         SEARCH_OR_CREATE = "search_or_create"

--- a/checker/configs/checker.py
+++ b/checker/configs/checker.py
@@ -51,15 +51,15 @@ class CheckerExportConfig(CustomBaseModel):
             For example:
             ```python
             a = 1
-            # TEMPLATE START
+            # SOLUTION BEGIN
             a = 2
-            # TEMPLATE END
+            # SOLUTION END
             b = 3
             ```
             will be converted to:
             ```python
             a = 1
-            # TODO: Your code
+            # TODO: Your solution
             b = 3
             ```
             Delete file if it is empty after template comments deletion.

--- a/checker/course.py
+++ b/checker/course.py
@@ -49,9 +49,9 @@ class Course:
         self.reference_root = reference_root or repository_root
 
         self.potential_groups = {
-            group.name: group for group in self._search_for_groups_by_configs(self.repository_root)
+            group.name: group for group in self._search_for_groups_by_configs(self.reference_root)
         }
-        self.potential_tasks = {task.name: task for task in self._search_for_tasks_by_configs(self.repository_root)}
+        self.potential_tasks = {task.name: task for task in self._search_for_tasks_by_configs(self.reference_root)}
 
     def validate(self) -> None:
         # check all groups and tasks mentioned in deadlines exists
@@ -63,7 +63,7 @@ class Course:
         deadlines_tasks = self.deadlines.get_tasks(enabled=True)
         for deadlines_task in deadlines_tasks:
             if deadlines_task.name not in self.potential_tasks:
-                raise BadConfig(f"Task {deadlines_task.name} of not found in repository")
+                raise BadConfig(f"Task {deadlines_task.name} not found in repository")
 
     def get_groups(
         self,
@@ -97,7 +97,7 @@ class Course:
             relative_task_path = task_config_path.parent.relative_to(root)
 
             # if empty file - use default
-            if task_config_path.read_text().strip() == "" or task_config_path.read_text().strip() == "\n":
+            if task_config_path.read_text().strip() == "":
                 task_config = CheckerSubConfig.default()
             # if any content - read yml
             else:

--- a/checker/course.py
+++ b/checker/course.py
@@ -48,9 +48,7 @@ class Course:
         self.repository_root = repository_root
         self.reference_root = reference_root or repository_root
 
-        self.potential_groups = {
-            group.name: group for group in self._search_for_groups_by_configs(self.reference_root)
-        }
+        self.potential_groups = {group.name: group for group in self._search_for_groups_by_configs(self.reference_root)}
         self.potential_tasks = {task.name: task for task in self._search_for_tasks_by_configs(self.reference_root)}
 
     def validate(self) -> None:

--- a/checker/exporter.py
+++ b/checker/exporter.py
@@ -18,9 +18,9 @@ class Exporter:
     """
 
     TEMPLATE_SUFFIX = ".template"
-    TEMPLATE_START_COMMENT = "TEMPLATE START"
-    TEMPLATE_END_COMMENT = "TEMPLATE END"
-    TEMPLATE_REPLACE_COMMENT = "TODO: Your code"
+    TEMPLATE_START_COMMENT = "SOLUTION BEGIN"
+    TEMPLATE_END_COMMENT = "SOLUTION END"
+    TEMPLATE_REPLACE_COMMENT = "TODO: Your solution"
     TEMPLATE_COMMENT_REGEX = re.compile(f"{TEMPLATE_START_COMMENT}(.*?){TEMPLATE_END_COMMENT}", re.DOTALL)
 
     def __init__(
@@ -94,7 +94,12 @@ class Exporter:
                 if potential_comments_file.is_dir():
                     continue
                 with potential_comments_file.open("r") as f:
-                    file_content = f.read()
+                    # skip binary files
+                    try:
+                        file_content = f.read()
+                    except UnicodeDecodeError:
+                        continue
+
                     # validate using regex and count matches of start and end comments
                     if self.TEMPLATE_START_COMMENT in file_content or self.TEMPLATE_END_COMMENT in file_content:
                         task_has_template_comments = True

--- a/checker/exporter.py
+++ b/checker/exporter.py
@@ -100,19 +100,24 @@ class Exporter:
                         task_has_template_comments = True
 
                         # check have equal num of comments
-                        if (file_content.count(self.TEMPLATE_START_COMMENT) != file_content.count(self.TEMPLATE_END_COMMENT)):
+                        if file_content.count(self.TEMPLATE_START_COMMENT) != file_content.count(
+                            self.TEMPLATE_END_COMMENT
+                        ):
                             task_has_valid_template_comments = False
                             raise BadStructure(
                                 f"Task {task.name} has invalid template comments in file {potential_comments_file}. "
-                                f"The number of <{self.TEMPLATE_START_COMMENT}> and <{self.TEMPLATE_END_COMMENT}> do not match"
+                                f"The number of <{self.TEMPLATE_START_COMMENT}> and "
+                                f"<{self.TEMPLATE_END_COMMENT}> do not match"
                             )
                         # check between comments no other comment pair
                         for match in self.TEMPLATE_COMMENT_REGEX.finditer(file_content):
-                            if self.TEMPLATE_START_COMMENT in match.group(1) or self.TEMPLATE_END_COMMENT in match.group(1):
+                            if self.TEMPLATE_START_COMMENT in match.group(
+                                1
+                            ) or self.TEMPLATE_END_COMMENT in match.group(1):
                                 task_has_valid_template_comments = False
                                 raise BadStructure(
-                                    f"Task {task.name} has invalid template comments in file {potential_comments_file}. "
-                                    f"There is <{self.TEMPLATE_START_COMMENT}> or <{self.TEMPLATE_END_COMMENT}> "
+                                    f"Task {task.name} has invalid template comments in file {potential_comments_file}."
+                                    f" There is <{self.TEMPLATE_START_COMMENT}> or <{self.TEMPLATE_END_COMMENT}> "
                                     f"between valid pair of comments"
                                 )
 
@@ -153,16 +158,16 @@ class Exporter:
                 assert False, "Not Reachable"
 
     def _search_for_exclude_due_to_templates(
-            self,
-            root: Path,
-            ignore_templates: bool,
+        self,
+        root: Path,
+        ignore_templates: bool,
     ) -> list[str]:
         """Search for files/folder should be ignored due to templating in the current directory only"""
         exclude_paths = []
 
         if (
-                self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH
-                or self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH_OR_CREATE
+            self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH
+            or self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH_OR_CREATE
         ):
             for template_file_or_folder in root.glob(f"*{self.TEMPLATE_SUFFIX}"):
                 if ignore_templates:
@@ -171,8 +176,8 @@ class Exporter:
                     exclude_paths.append(template_file_or_folder.stem)
 
         if (
-                self.export_config.templates == CheckerExportConfig.TemplateType.CREATE
-                or self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH_OR_CREATE
+            self.export_config.templates == CheckerExportConfig.TemplateType.CREATE
+            or self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH_OR_CREATE
         ):
             # if got empty file after template comments deletion - exclude it
             for potential_comments_file in root.glob("*"):
@@ -180,9 +185,8 @@ class Exporter:
                     continue
                 with potential_comments_file.open("r") as f:
                     file_content = f.read().strip()
-                    if (
-                            file_content.startswith(self.TEMPLATE_START_COMMENT)
-                            and file_content.endswith(self.TEMPLATE_END_COMMENT)
+                    if file_content.startswith(self.TEMPLATE_START_COMMENT) and file_content.endswith(
+                        self.TEMPLATE_END_COMMENT
                     ):
                         exclude_paths.append(potential_comments_file.name)
 
@@ -304,8 +308,19 @@ class Exporter:
         for path in root.iterdir():
             path_destination = destination / path.relative_to(root)
             # check if file template
-            is_path_template_file = (self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH or self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH_OR_CREATE) and path.name.endswith(self.TEMPLATE_SUFFIX)
-            is_path_template_comment = (self.export_config.templates == CheckerExportConfig.TemplateType.CREATE or self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH_OR_CREATE) and not path.is_dir() and self.TEMPLATE_START_COMMENT in path.read_text() and self.TEMPLATE_END_COMMENT in path.read_text()
+            is_path_template_file = (
+                self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH
+                or self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH_OR_CREATE
+            ) and path.name.endswith(self.TEMPLATE_SUFFIX)
+            is_path_template_comment = (
+                (
+                    self.export_config.templates == CheckerExportConfig.TemplateType.CREATE
+                    or self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH_OR_CREATE
+                )
+                and not path.is_dir()
+                and self.TEMPLATE_START_COMMENT in path.read_text()
+                and self.TEMPLATE_END_COMMENT in path.read_text()
+            )
 
             # if will replace with template - ignore file
             if path.name in exclude_paths:

--- a/checker/exporter.py
+++ b/checker/exporter.py
@@ -368,7 +368,7 @@ class Exporter:
             # Note: never skip "other" directories, look inside them first
             if not is_public and not is_private and not path.is_dir():
                 if not copy_other:
-                    print(f"    - Skip <{path.relative_to(global_root)}> because skip other files not enabled")
+                    print(f"    - Skip <{path.relative_to(global_root)}> because copy other files not enabled")
                     continue
 
             # if file is empty file/folder - just do not copy (delete original file due to exclude_paths)

--- a/checker/exporter.py
+++ b/checker/exporter.py
@@ -1,21 +1,33 @@
 from __future__ import annotations
 
+import re
 import shutil
 import tempfile
 from pathlib import Path
 
 from checker.configs import CheckerExportConfig, CheckerStructureConfig
 from checker.course import Course
+from checker.exceptions import BadStructure
 
 
 class Exporter:
+    """
+    The Exporter class is responsible for moving course files.
+    1. It validates and manage templates
+    2. Select files to be exported public/testing/contribution
+    """
+
+    TEMPLATE_SUFFIX = ".template"
+    TEMPLATE_START_COMMENT = "TEMPLATE START"
+    TEMPLATE_END_COMMENT = "TEMPLATE END"
+    TEMPLATE_REPLACE_COMMENT = "TODO: Your code"
+    TEMPLATE_COMMENT_REGEX = re.compile(f"{TEMPLATE_START_COMMENT}(.*?){TEMPLATE_END_COMMENT}", re.DOTALL)
+
     def __init__(
         self,
         course: Course,
         structure_config: CheckerStructureConfig,
         export_config: CheckerExportConfig,
-        repository_root: Path,
-        reference_root: Path | None = None,
         *,
         cleanup: bool = True,
         verbose: bool = False,
@@ -26,8 +38,8 @@ class Exporter:
         self.structure_config = structure_config
         self.export_config = export_config
 
-        self.repository_root = repository_root
-        self.reference_root = reference_root or repository_root
+        self.repository_root = course.repository_root
+        self.reference_root = course.reference_root
 
         self._temporary_dir_manager = tempfile.TemporaryDirectory()
         self.temporary_dir = Path(self._temporary_dir_manager.name)
@@ -47,8 +59,134 @@ class Exporter:
         self.dry_run = dry_run
 
     def validate(self) -> None:
-        # TODO: implement validation
-        pass
+        # validate course
+        self.course.validate()
+
+        # TODO: validate structure correct glob patterns
+
+        # validate templates
+        # `original.template` files/folders need to have `original` file/folder
+        # template comments have to be paired
+        # template comments can not be one inside another
+        # if `templates` is set to `SEARCH` - only `.template` allowed
+        # if `templates` is set to `CREATE` - only template comments allowed
+        # if `templates` is set to `SEARCH_OR_CREATE` - both allowed, but one inside one task
+        for task in self.course.get_tasks(enabled=True):
+            # TODO: check template not public and not private file
+
+            task_folder = self.reference_root / task.relative_path
+            task_has_template_files, task_has_valid_template_files = False, False
+            task_has_template_comments, task_has_valid_template_comments = False, False
+
+            # search for all `.template` files or folders
+            for template_file_or_folder in task_folder.glob(f"**/*{self.TEMPLATE_SUFFIX}"):
+                task_has_template_files = True
+                # check that all files have original files
+                if not (template_file_or_folder.parent / template_file_or_folder.stem).exists():
+                    raise BadStructure(
+                        f"Template file/folder {template_file_or_folder} does not have "
+                        f"original file/folder {self.reference_root / template_file_or_folder.stem}"
+                    )
+                task_has_valid_template_files = True
+
+            # check all (not binary) files for template comments
+            for potential_comments_file in task_folder.glob("**/*"):
+                if potential_comments_file.is_dir():
+                    continue
+                with potential_comments_file.open("r") as f:
+                    file_content = f.read()
+                    # validate using regex and count matches of start and end comments
+                    if self.TEMPLATE_START_COMMENT in file_content or self.TEMPLATE_END_COMMENT in file_content:
+                        task_has_template_comments = True
+
+                        # check have equal num of comments
+                        if (file_content.count(self.TEMPLATE_START_COMMENT) != file_content.count(self.TEMPLATE_END_COMMENT)):
+                            task_has_valid_template_comments = False
+                            raise BadStructure(
+                                f"Task {task.name} has invalid template comments in file {potential_comments_file}. "
+                                f"The number of <{self.TEMPLATE_START_COMMENT}> and <{self.TEMPLATE_END_COMMENT}> do not match"
+                            )
+                        # check between comments no other comment pair
+                        for match in self.TEMPLATE_COMMENT_REGEX.finditer(file_content):
+                            if self.TEMPLATE_START_COMMENT in match.group(1) or self.TEMPLATE_END_COMMENT in match.group(1):
+                                task_has_valid_template_comments = False
+                                raise BadStructure(
+                                    f"Task {task.name} has invalid template comments in file {potential_comments_file}. "
+                                    f"There is <{self.TEMPLATE_START_COMMENT}> or <{self.TEMPLATE_END_COMMENT}> "
+                                    f"between valid pair of comments"
+                                )
+
+                        task_has_valid_template_comments = True
+
+            if self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH:
+                if task_has_template_comments:
+                    raise BadStructure(
+                        f"Templating set to {self.export_config.templates} but task {task.name} has "
+                        f"template comments <{self.TEMPLATE_START_COMMENT}> and <{self.TEMPLATE_END_COMMENT}>"
+                    )
+                if not task_has_valid_template_files:
+                    raise BadStructure(
+                        f"Task {task.name} does not have `.template` file/folder. Have to include at least one"
+                    )
+            elif self.export_config.templates == CheckerExportConfig.TemplateType.CREATE:
+                if task_has_template_files:
+                    raise BadStructure(
+                        f"Templating set to {self.export_config.templates} but task {task.name} has "
+                        f"`.template` file/folder"
+                    )
+                if not task_has_valid_template_comments:
+                    raise BadStructure(
+                        f"Task {task.name} does not have template comments. Have to include at least one pair of "
+                        f"<{self.TEMPLATE_START_COMMENT}> and <{self.TEMPLATE_END_COMMENT}>"
+                    )
+            elif self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH_OR_CREATE:
+                if task_has_template_files and task_has_template_comments:
+                    raise BadStructure(
+                        f"Task {task.name} can not use both `.template` file/folder and template comments"
+                    )
+                if not task_has_valid_template_files and not task_has_valid_template_comments:
+                    raise BadStructure(
+                        f"Task {task.name} does not have `.template` file/folder or at least one pair of "
+                        f"<{self.TEMPLATE_START_COMMENT}> and <{self.TEMPLATE_END_COMMENT}>"
+                    )
+            else:  # pragma: no cover
+                assert False, "Not Reachable"
+
+    def _search_for_exclude_due_to_templates(
+            self,
+            root: Path,
+            ignore_templates: bool,
+    ) -> list[str]:
+        """Search for files/folder should be ignored due to templating in the current directory only"""
+        exclude_paths = []
+
+        if (
+                self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH
+                or self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH_OR_CREATE
+        ):
+            for template_file_or_folder in root.glob(f"*{self.TEMPLATE_SUFFIX}"):
+                if ignore_templates:
+                    exclude_paths.append(template_file_or_folder.name)
+                else:
+                    exclude_paths.append(template_file_or_folder.stem)
+
+        if (
+                self.export_config.templates == CheckerExportConfig.TemplateType.CREATE
+                or self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH_OR_CREATE
+        ):
+            # if got empty file after template comments deletion - exclude it
+            for potential_comments_file in root.glob("*"):
+                if potential_comments_file.is_dir():
+                    continue
+                with potential_comments_file.open("r") as f:
+                    file_content = f.read().strip()
+                    if (
+                            file_content.startswith(self.TEMPLATE_START_COMMENT)
+                            and file_content.endswith(self.TEMPLATE_END_COMMENT)
+                    ):
+                        exclude_paths.append(potential_comments_file.name)
+
+        return exclude_paths
 
     def export_public(
         self,
@@ -66,6 +204,7 @@ class Exporter:
             copy_public=True,
             copy_private=False,
             copy_other=True,
+            fill_templates=True,
         )
 
     def export_for_testing(
@@ -82,6 +221,7 @@ class Exporter:
             copy_public=False,
             copy_private=False,
             copy_other=True,
+            fill_templates=False,
         )
 
         print(f"Copy from {self.reference_root} to {target}")
@@ -92,6 +232,7 @@ class Exporter:
             copy_public=True,
             copy_private=True,
             copy_other=False,
+            fill_templates=False,
         )
 
     def export_for_contribution(
@@ -108,6 +249,7 @@ class Exporter:
             copy_public=True,
             copy_private=False,
             copy_other=True,
+            fill_templates=False,
         )
 
         print(f"Copy from {self.reference_root} to {target}")
@@ -118,6 +260,7 @@ class Exporter:
             copy_public=False,
             copy_private=True,
             copy_other=True,
+            fill_templates=False,
         )
 
     def _copy_files_with_config(
@@ -128,6 +271,7 @@ class Exporter:
         copy_public: bool,
         copy_private: bool,
         copy_other: bool,
+        fill_templates: bool,
         global_root: Path | None = None,
         global_destination: Path | None = None,
     ) -> None:
@@ -141,6 +285,7 @@ class Exporter:
         :param copy_public: Copy public files
         :param copy_private: Copy private files
         :param copy_other: Copy other - not public and not private files
+        :param fill_templates: Fill templates (`.template` or template comments), if false will delete them
         :param global_root: Starting root directory
         :param global_destination: Starting destination directory
         """
@@ -152,14 +297,24 @@ class Exporter:
         print(f"Copy files from <{root.relative_to(global_root)}> to <{destination.relative_to(global_destination)}>")
         print(f"  {config=}")
 
+        # select paths to ignore - original to replace or templates to ignore
+        exclude_paths = self._search_for_exclude_due_to_templates(root, not fill_templates)
+
         # Iterate over all files in the root directory
         for path in root.iterdir():
-            # print(f" - {path.relative_to(global_root)}")
-            # ignore if match the patterns
+            path_destination = destination / path.relative_to(root)
+            # check if file template
+            is_path_template_file = (self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH or self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH_OR_CREATE) and path.name.endswith(self.TEMPLATE_SUFFIX)
+            is_path_template_comment = (self.export_config.templates == CheckerExportConfig.TemplateType.CREATE or self.export_config.templates == CheckerExportConfig.TemplateType.SEARCH_OR_CREATE) and not path.is_dir() and self.TEMPLATE_START_COMMENT in path.read_text() and self.TEMPLATE_END_COMMENT in path.read_text()
+
+            # if will replace with template - ignore file
+            if path.name in exclude_paths:
+                print(f"    - Skip <{path.relative_to(global_root)}> because of templating")
+                continue
+
+            # ignore if match ignore patterns
             if config.ignore_patterns and any(path.match(ignore_pattern) for ignore_pattern in config.ignore_patterns):
-                print(
-                    f"    - Skip <{path.relative_to(global_root)}> because ignore patterns=[{config.ignore_patterns}]"
-                )
+                print(f"    - Skip <{path.relative_to(global_root)}> because ignore patterns={config.ignore_patterns}")
                 continue
 
             # If matches public patterns AND copy_public is False - skip
@@ -169,7 +324,7 @@ class Exporter:
                 if not copy_public:
                     print(
                         f"    - Skip <{path.relative_to(global_root)}> because skip "
-                        f"public_patterns=[{config.public_patterns}]"
+                        f"public_patterns={config.public_patterns}"
                     )
                     continue
 
@@ -185,7 +340,7 @@ class Exporter:
                 if not copy_private:
                     print(
                         f"    - Skip <{path.relative_to(global_root)}> because skip "
-                        f"private_patterns=[{config.private_patterns}]"
+                        f"private_patterns={config.private_patterns}"
                     )
                     continue
 
@@ -193,7 +348,22 @@ class Exporter:
             # Note: never skip "other" directories, look inside them first
             if not is_public and not is_private and not path.is_dir():
                 if not copy_other:
-                    print(f"    - Skip <{path.relative_to(global_root)}> because " f"skip other files not enabled")
+                    print(f"    - Skip <{path.relative_to(global_root)}> because skip other files not enabled")
+                    continue
+
+            # if file is empty file/folder - just do not copy (delete original file due to exclude_paths)
+            if fill_templates and is_path_template_file:
+                if path.is_dir() and not any((path_destination / file).exists() for file in path.iterdir()):
+                    print(
+                        f"    - Skip <{path.relative_to(global_root)}> because it is empty folder and "
+                        f"templating is set to {self.export_config.templates}"
+                    )
+                    continue
+                if path.is_file() and path.stat().st_size == 0:
+                    print(
+                        f"    - Skip <{path.relative_to(global_root)}> because it is empty file and "
+                        f"templating is set to {self.export_config.templates}"
+                    )
                     continue
 
             # If the file is a directory, recursively call this function
@@ -202,24 +372,24 @@ class Exporter:
                 if is_public or is_private:
                     print(
                         f"    - Fully Copy <{path.relative_to(global_root)}> to "
-                        f"<{(destination / path.relative_to(root)).relative_to(global_destination)}>"
+                        f"<{path_destination.relative_to(global_destination)}>"
                     )
-                    # TODO: think call recursive function with =True for all to apply ignore
-                    # shutil.copytree(
-                    #     path,
-                    #     destination / path.relative_to(root),
-                    # )
-                    # continue
                     self._copy_files_with_config(
                         path,
-                        destination / path.relative_to(root),
+                        path_destination,
                         config,
                         copy_public=True,
                         copy_private=True,
                         copy_other=True,
+                        fill_templates=fill_templates,
                         global_root=global_root,
                         global_destination=global_destination,
                     )
+                    continue
+
+                # If directory `origin.template` - copy from this folder to `origin`
+                if fill_templates and is_path_template_file:
+                    path_destination = path_destination.parent / path_destination.stem
 
                 # If have sub-config - update config with sub-config
                 if path.relative_to(global_root) in self.sub_config_files:
@@ -241,15 +411,16 @@ class Exporter:
                 # Recursively call this function
                 print(
                     f"    -- Recursively copy from <{path.relative_to(global_root)}> to "
-                    f"<{(destination / path.relative_to(root)).relative_to(global_destination)}>"
+                    f"<{path_destination.relative_to(global_destination)}>"
                 )
                 self._copy_files_with_config(
                     path,
-                    destination / path.relative_to(root),
+                    path_destination,
                     sub_config,
                     copy_public,
                     copy_private,
                     copy_other,
+                    fill_templates,
                     global_root=global_root,
                     global_destination=global_destination,
                 )
@@ -257,13 +428,26 @@ class Exporter:
             else:
                 print(
                     f"    - Copy <{path.relative_to(global_root)}> to "
-                    f"<{(destination / path.relative_to(root)).relative_to(global_destination)}>"
+                    f"<{path_destination.relative_to(global_destination)}>"
                 )
-                (destination / path.relative_to(root)).parent.mkdir(parents=True, exist_ok=True)
-                shutil.copyfile(
-                    path,
-                    destination / path.relative_to(root),
-                )
+                path_destination.parent.mkdir(parents=True, exist_ok=True)
+
+                # if `origin.template` - copy from this file as `origin`
+                if fill_templates and is_path_template_file:
+                    path_destination = path_destination.parent / path_destination.stem
+
+                # if template comments in file - replace them, not greedy
+                if fill_templates and is_path_template_comment:
+                    with path.open("r") as f:
+                        file_content = f.read()
+                    file_content = self.TEMPLATE_COMMENT_REGEX.sub(self.TEMPLATE_REPLACE_COMMENT, file_content)
+                    path_destination.touch(exist_ok=True)
+                    path_destination.write_text(file_content)
+                else:
+                    shutil.copyfile(
+                        path,
+                        path_destination,
+                    )
 
     def __del__(self) -> None:
         if self.__dict__.get("cleanup") and self._temporary_dir_manager:

--- a/docs/1_getting_started.md
+++ b/docs/1_getting_started.md
@@ -41,7 +41,7 @@ Here's a detailed breakdown:
 ```yaml
 group_1/
     task_1/
-      .template/  # optional, can extract from solution files
+      [solution files].template  # file or folder, if set templates="search" in .checker.yml
         [some files]
       [gold solution files]
       [some private tests]
@@ -59,9 +59,11 @@ group_2/
 .deadlines.yml  # deadlines config with task scores to send to manytask
 ```
 
-
 !!! warning  
     Groups and tasks names have to be unique.
+
+!!! warning  
+    You have to provide solution templates for each task. Please refer to [Templates](#templates) section for more details.
 
 !!! note  
     By default ".*" files are considered as private and not copied to public repo, but you can change it in the config.
@@ -69,7 +71,53 @@ group_2/
 Additionally, you can have any files in like `group_1/.lecture` folder or `tools/my_course_tools` folder.  
 Also, probably you want to have `.docker` file with your test environment and `.gitlab-ci-students.yml` file to run tests in CI.
 
+
 After [Configuration](#configuration), you can validate your layout with `checker validate` command.
+
+## Templates
+
+The aim of the checker to provide as close as possible environment for students and teachers to test solutions.  
+That's why we have templates. Teachers store the gold solution file the same place the student will and template applied only when exporting repo for students.
+
+You have to provide solution templates for each task. You have 3 options to setup in `.checker.yml` (see [Configuration](#configuration) for details):
+
+* `templates: "search"` - checker will search for files or folders with `.template` extension in the task directory and use them as templates.  
+    Original file/folder will be deleted and replaced with a template (`.template` extension will be removed).  
+    For example, if you have `task_1/solution.py.template` file, checker will use it as a template to replace gold solution `task_1/solution.py` file.  
+    This is the default option.
+    
+    If you have an empty file/folder with `.template` extension, checker will just delete original file/folder.
+
+* `templates: "create"` - checker will search for the template comments in your gold solution and will delete everything except the template.  
+    For example, if you have `task_1/solution.py` file with a pair of comments `BEGIN SOLUTION` and `END SOLUTION`:
+    ```python
+    a = 1
+    # BEGIN SOLUTION
+    print(a)
+    # END SOLUTION
+    b = a + 1
+    # BEGIN SOLUTION
+    print(b)
+    # END SOLUTION
+    ```
+    When exporting to public checker will replace it with `TODO: Your solution`:
+    ```python
+    a = 1
+    # TODO: Your solution
+    b = a + 1
+    # TODO: Your solution
+    ```
+    Note: You can have multiple templates in one file.  
+    Note2: If you write both `BEGIN SOLUTION` and `END SOLUTION` as comments, resulting `TODO: Your solution` will be a comment as well.
+    
+    If after templating the file is empty, checker will delete it.
+  
+* `templates: "search_or_create" - checker will try to use `search` and if it fails, it will use `create`.  
+   You CAN NOT have 2 types of templating in the same task, but can use any of them in different tasks.  
+    
+
+!!! warning  
+    Each task have to have at least one template file or folder.
 
 
 ## Testing environment

--- a/docs/1_getting_started.md
+++ b/docs/1_getting_started.md
@@ -89,26 +89,28 @@ You have to provide solution templates for each task. You have 3 options to setu
     If you have an empty file/folder with `.template` extension, checker will just delete original file/folder.
 
 * `templates: "create"` - checker will search for the template comments in your gold solution and will delete everything except the template.  
-    For example, if you have `task_1/solution.py` file with a pair of comments `BEGIN SOLUTION` and `END SOLUTION`:
+    For example, if you have `task_1/solution.py` file with a pair of comments `SOLUTION BEGIN` and `SOLUTION END`:
     ```python
     a = 1
-    # BEGIN SOLUTION
+    # SOLUTION BEGIN
     print(a)
-    # END SOLUTION
+    # SOLUTION END
     b = a + 1
-    # BEGIN SOLUTION
+    b += 1
+    # SOLUTION BEGIN
     print(b)
-    # END SOLUTION
+    # SOLUTION END
     ```
-    When exporting to public checker will replace it with `TODO: Your solution`:
+    When exporting to public checker will replace it with `TODO: Your solution` in NOT-greedy way:
     ```python
     a = 1
     # TODO: Your solution
     b = a + 1
+    b += 1
     # TODO: Your solution
     ```
     Note: You can have multiple templates in one file.  
-    Note2: If you write both `BEGIN SOLUTION` and `END SOLUTION` as comments, resulting `TODO: Your solution` will be a comment as well.
+    Note2: If you write both `SOLUTION BEGIN` and `SOLUTION END` as comments, resulting `TODO: Your solution` will be a comment as well.
     
     If after templating the file is empty, checker will delete it.
   

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -26,7 +26,7 @@ TEST_FILE_STRUCTURE = {
     "group2": {
         "task2_1": {".task.yml": "", "file2_1_1": "", "file2_1_2": ""},
         "task2_2": {".task.yml": "version: 1"},
-        "task2_3": {".task.yml": "\n", "file2_3_1": "", "file2_3_2": "", "file2_3_3": "", "file2_3_4": ""},
+        "task2_3": {".task.yml": " \n  \n", "file2_3_1": "", "file2_3_2": "", "file2_3_3": "", "file2_3_4": ""},
         "random_folder": {"file1": "", "file2": ""},
         ".group.yml": "version: 1",
     },

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from checker.configs import CheckerExportConfig, CheckerStructureConfig, DeadlinesConfig
 from checker.course import Course
-from checker.exceptions import BadConfig
+from checker.exceptions import BadConfig, BadStructure
 from checker.exporter import Exporter
 
 from .conftest import T_GENERATE_FILE_STRUCTURE
@@ -23,8 +24,347 @@ def assert_files_in_folder(folder: Path, expected_files: list[str]) -> None:
         assert str(file.relative_to(folder)) in expected_files, f"File {file.relative_to(folder)} not expected"
 
 
-# TODO: extend tests
-class TestExporter:
+class TestExporterOnSimple:
+    @pytest.fixture()
+    def simple_deadlines(self) -> DeadlinesConfig:
+        return DeadlinesConfig(
+            version=1,
+            settings={"timezone": "Europe/Berlin"},
+            schedule=[
+                {
+                    "group": "no_folder_group",
+                    "enabled": True,
+                    "start": "2021-01-01 00:00:00",
+                    "tasks": [
+                        {"task": "task1", "score": 1},
+                        {"task": "task2", "score": 1},
+                    ],
+                },
+            ],
+        )
+
+    @pytest.fixture()
+    def simple_structure(self) -> CheckerStructureConfig:
+        return CheckerStructureConfig(
+            ignore_patterns=[".ignore_me"],
+            private_patterns=[".*"],
+            public_patterns=["public*"],
+        )
+
+    @pytest.fixture()
+    def simple_export_config(self) -> CheckerExportConfig:
+        return CheckerExportConfig(
+            destination="https://example.com",
+            templates="search_or_create",
+        )
+
+    @pytest.fixture()
+    def simple_private_layout(self, tmpdir: Path, generate_file_structure: T_GENERATE_FILE_STRUCTURE) -> Path:
+        layout = {
+            "task1": {".task.yml": "version: 1\nstructure:\n    ignore_patterns: [extra_ignore_me]\n", "test.txt": "Some TEMPLATE START\nHello\nTEMPLATE END\n", "public_file.py": "print('Hello')\n", "extra_ignore_me": ""},
+            "task2": {".task.yml": "", "test.txt": "Some", "test.txt.template": "Will replace the file", ".private.file": "private\n"},
+            ".ignore_me": "",
+            "just_file": "hey",
+            ".private.file": "private\n",
+            "public_folder": {"file_in_public_folder": "file"},
+            "public_file.py": "print('Hello')\n",
+        }
+        generate_file_structure(layout, Path(tmpdir / "repository"))
+        return Path(tmpdir / "repository")
+
+    @pytest.fixture()
+    def simple_student_layout(self, tmpdir: Path, generate_file_structure: T_GENERATE_FILE_STRUCTURE) -> Path:
+        layout = {
+            "task1": {"test.txt": "Some Changes", "public_file.py": "print('Hello LOL this too')\n"},
+            "task2": {"test.txt": "Student changed it"},
+            "just_file": "hey",
+            "public_folder": {"file_in_public_folder": "try to change"},
+            "public_file.py": "print('Hello')\n",
+        }
+        generate_file_structure(layout, Path(tmpdir / "student"))
+        return Path(tmpdir / "student")
+
+    @pytest.fixture()
+    def simple_exporter(
+        self,
+        tmpdir: Path,
+        simple_private_layout: Path,
+        simple_student_layout: Path,
+        simple_deadlines: DeadlinesConfig,
+        simple_structure: CheckerStructureConfig,
+        simple_export_config: CheckerExportConfig,
+    ) -> Exporter:
+        course = Course(
+            deadlines=simple_deadlines,
+            repository_root=simple_student_layout,
+            reference_root=simple_private_layout,
+        )
+        return Exporter(
+            course,
+            simple_structure,
+            simple_export_config,
+        )
+
+    def test_simple_validate_ok(self, tmpdir: Path, simple_exporter: Exporter) -> None:
+        simple_exporter.validate()
+
+    def test_simple_validate_mix_templates_in_task(self, tmpdir: Path, simple_exporter: Exporter) -> None:
+        # add other time to existing tasks
+        Path(tmpdir / "repository" / "task1" / "new.txt").touch()
+        Path(tmpdir / "repository" / "task1" / "new.txt.template").touch()
+        Path(tmpdir / "repository" / "task2" / "new.txt").touch()
+        Path(tmpdir / "repository" / "task2" / "new.txt").write_text("Some\n TEMPLATE START\nHello\nTEMPLATE END\n", encoding="utf-8")
+
+        with pytest.raises(BadStructure) as exc_info:
+            simple_exporter.validate()
+        assert "use both" in str(exc_info.value)
+
+    @pytest.mark.parametrize("template_type", [CheckerExportConfig.TemplateType.CREATE, CheckerExportConfig.TemplateType.SEARCH])
+    def test_simple_validate_no_templates(self, tmpdir: Path, simple_exporter: Exporter, template_type: str) -> None:
+        simple_exporter.export_config.templates = template_type
+
+        # delete comment template, make wrong .template file
+        Path(tmpdir / "repository" / "task1" / "test.txt").write_text("Some\n")
+        Path(tmpdir / "repository" / "task2" / "not_original_file.txt.template").touch()
+
+        with pytest.raises(BadStructure) as exc_info:
+            simple_exporter.validate()
+        assert "Have to include at least" in str(exc_info.value)
+
+    @pytest.mark.parametrize("template_type", [CheckerExportConfig.TemplateType.SEARCH, CheckerExportConfig.TemplateType.SEARCH_OR_CREATE])
+    def test_simple_validate_no_original_file_for_templates(self, tmpdir: Path, simple_exporter: Exporter, template_type: str) -> None:
+        simple_exporter.export_config.templates = template_type
+
+        # delete all templates files
+        Path(tmpdir / "repository" / "task1" / "test.txt").unlink()
+        Path(tmpdir / "repository" / "task1" / "test.txt.template").touch()
+
+        with pytest.raises(BadStructure) as exc_info:
+            simple_exporter.validate()
+        assert "does not have original" in str(exc_info.value)
+
+    @pytest.mark.parametrize("template_type", [CheckerExportConfig.TemplateType.CREATE, CheckerExportConfig.TemplateType.SEARCH])
+    def test_simple_validate_wrong_template_type(self, tmpdir: Path, simple_exporter: Exporter, template_type: str) -> None:
+        simple_exporter.export_config.templates = template_type
+
+        with pytest.raises(BadStructure) as exc_info:
+            simple_exporter.validate()
+        assert "Templating set to" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "file_content", [
+            "TEM!PLATE START\nHello\nTEMPLATE END\n",
+            "TEMPLATE START\nHello\nTEMPL!ATE END\n",
+            "Hello\n",
+            "TEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE START\nHello\nTEMP!LATE END\n",
+            "TEMPLATE START\nHello\nTEMPLATE END\n\nHello\nTEMPLATE END\n",
+            "TEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE START\nHello\n",
+            "TEMPLATE START\nTEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE END",
+        ]
+    )
+    def test_simple_validate_wrong_template_comment(self, tmpdir: Path, simple_exporter: Exporter, file_content: str) -> None:
+        simple_exporter.export_config.templates = CheckerExportConfig.TemplateType.CREATE
+
+        # remove .template and write comment-style template
+        Path(tmpdir / "repository" / "task2" / "test.txt.template").unlink()
+        (tmpdir / "repository" / "task2" / "test.txt").write_text(file_content, encoding="utf-8")
+
+        with pytest.raises(BadStructure) as exc_info:
+            simple_exporter.validate()
+        assert "invalid template comments" in str(exc_info.value) or "does not have template comments" in str(exc_info.value)
+
+    # TODO: ignore_templates tests
+    @pytest.mark.parametrize(
+        "file_structure, expected_excluded_paths",
+        [
+            (
+                {},
+                [],
+            ),
+            (
+                {"some_folder": {"some_file.txt": "123", "empty_file.py": ""}, "other_file": "123"},
+                [],
+            ),
+            (
+                {"some_folder": {"some_file.txt": "123", "not_in_the_root_folder.py": "TEMPLATE START\nTEMPLATE END"}, "other_file": "123"},
+                [],  # search in current dir only
+            ),
+            (
+                {"some_folder": {"some_file.txt": "123"}, "empty_after_template_file.py": "TEMPLATE START\nTEMPLATE END"},
+                ["empty_after_template_file.py"],
+            ),
+            (
+                {"some_folder": {"some_file.txt": "123"}, "empty_after_template_file.py": "   \n\n  TEMPLATE START\n\nTEMPLATE END\n\t\n"},
+                ["empty_after_template_file.py"]
+            ),
+            (
+                {"some_folder": {"some_file.txt.template": "123", "some_file.txt": "321", "empty_file.py": ""}, "other_file": "123"},
+                [],  # search in current dir only
+            ),
+            (
+                {"some_folder": {"empty_file.py": ""}, "some_file.txt.template": "123", "some_file.txt": "321"},
+                ["some_file.txt"],
+            ),
+            (
+                {"some_folder.template": {"some_file.txt": "123", "empty_file.py": ""}, "some_folder": {"some_file": ""}, "other_file": "123"},
+                ["some_folder"],
+            ),
+            (
+                {"some_folder": {"some_file.txt.template": "123", "some_file.txt": "321", "empty_file.py": ""}, "other_file": "TEMPLATE START\nTEMPLATE END", "other_other_file": "", "other_other_file.template": ""},
+                ["other_other_file", "other_file"],
+            ),
+        ],
+    )
+    def test_search_for_exclude_due_to_templates(self, tmpdir: Path, simple_exporter: Exporter, generate_file_structure: T_GENERATE_FILE_STRUCTURE, file_structure: dict[str, Any], expected_excluded_paths: list[str]) -> None:
+        # use other directory, not original Exporter one
+        generate_file_structure(file_structure, root=Path(tmpdir / "test_data"))
+
+        excluded_paths = simple_exporter._search_for_exclude_due_to_templates(Path(tmpdir / "test_data"), False)
+        assert sorted(excluded_paths) == sorted(expected_excluded_paths)
+
+    @pytest.mark.parametrize(
+        "copy_public, copy_private, copy_other, expected_files",
+        [
+            (True, False, False, ["task1/public_file.py", "public_file.py", "public_folder/file_in_public_folder"]),
+            (False, True, False, ["task1/.task.yml", "task2/.task.yml", "task2/.private.file", ".private.file"]),
+            (False, False, True, ["task1/test.txt", "task2/test.txt", "just_file"]),
+        ]
+    )
+    @pytest.mark.parametrize(
+        "fill_templates", [True, False],
+    )
+    def test_copy_files_with_config(self, tmpdir: Path, simple_exporter: Exporter, copy_public: bool, copy_private: bool, copy_other: bool, expected_files: list[str], fill_templates: bool) -> None:
+        source = Path(tmpdir / "repository")
+        destination = Path(tmpdir / "export")
+
+        simple_exporter._copy_files_with_config(
+            source, destination, simple_exporter.structure_config, copy_public, copy_private, copy_other, fill_templates
+        )
+
+        assert_files_in_folder(destination, expected_files)
+
+    @pytest.mark.parametrize("is_file", [True, False])
+    def test_copy_files_with_config_empty_template(self, tmpdir: Path, simple_exporter: Exporter, is_file: bool) -> None:
+        # set .template as empty file/folder will delete original file
+        if is_file:
+            Path(tmpdir / "repository" / "task2" / "test.txt.template").write_text("", encoding="utf-8")
+        else:
+            Path(tmpdir / "repository" / "task2" / "test.txt.template").unlink()
+            Path(tmpdir / "repository" / "task2" / "test.txt.template").mkdir()
+
+        simple_exporter._copy_files_with_config(
+            Path(tmpdir / "repository"), Path(tmpdir / "export"), simple_exporter.structure_config, False, False, True, True,
+        )
+
+        assert_files_in_folder(Path(tmpdir / "export"), ["task1/test.txt", "just_file"])
+
+    @pytest.mark.parametrize("is_source_file", [True, False])
+    @pytest.mark.parametrize("is_destination_file", [True, False])
+    def test_copy_files_with_config_template_is_file_or_folder(self, tmpdir: Path, simple_exporter: Exporter, is_source_file: bool, is_destination_file: bool) -> None:
+        repository = Path(tmpdir / "repository")
+        export = Path(tmpdir / "export")
+
+        # delete original template
+        Path(repository / "task2" / "test.txt").unlink()
+        Path(repository / "task2" / "test.txt.template").unlink()
+
+        # make template folder or file
+        if is_source_file:
+            Path(repository / "task2" / "test.txt.template").write_text("NEW TEXT", encoding="utf-8")
+        else:
+            Path(repository / "task2" / "test.txt.template").mkdir()
+            Path(repository / "task2" / "test.txt.template" / "new_file.txt").write_text("NEW TEXT", encoding="utf-8")
+
+        # make original folder or file
+        if is_destination_file:
+            Path(repository / "task2" / "test.txt").write_text("OLD TEXT", encoding="utf-8")
+        else:
+            Path(repository / "task2" / "test.txt").mkdir()
+            Path(repository / "task2" / "test.txt" / "old_file.txt").write_text("OLD TEXT", encoding="utf-8")
+
+        simple_exporter._copy_files_with_config(
+            repository, export, simple_exporter.structure_config, False, False, True, True,
+        )
+
+        # regardless of original file - just copy there template
+        if is_source_file:
+            assert (export / "task2" / "test.txt").is_file()
+            assert (export / "task2" / "test.txt").read_text(encoding="utf-8") == "NEW TEXT"
+        else:
+            assert (export / "task2" / "test.txt").is_dir()
+            assert (export / "task2" / "test.txt" / "new_file.txt").is_file()
+            assert (export / "task2" / "test.txt" / "new_file.txt").read_text(encoding="utf-8") == "NEW TEXT"
+
+    def test_export_public(self, tmpdir: Path, simple_exporter: Exporter) -> None:
+        simple_exporter.export_public(Path(tmpdir / "export"))
+
+        assert_files_in_folder(
+            Path(tmpdir / "export").resolve(),
+            [
+                "task1/test.txt",
+                "task1/public_file.py",
+                "task2/test.txt",
+                "just_file",
+                "public_folder/file_in_public_folder",
+                "public_file.py",
+            ],
+        )
+        # check templates was resolved if needed (all here)
+        assert (tmpdir / "export" / "task1" / "test.txt").read_text(encoding="utf-8") == "Some TODO: Your code\n"
+        assert (tmpdir / "export" / "task2" / "test.txt").read_text(encoding="utf-8") == "Will replace the file"
+
+    def test_export_for_testing(self, tmpdir: Path, simple_exporter: Exporter) -> None:
+        simple_exporter.export_for_testing(Path(tmpdir / "export"))
+
+        assert_files_in_folder(
+            Path(tmpdir / "export").resolve(),
+            [
+                "task1/.task.yml",
+                "task1/test.txt",
+                "task1/public_file.py",
+                "task2/.task.yml",
+                "task2/test.txt",
+                "task2/.private.file",
+                ".private.file",
+                "just_file",
+                "public_folder/file_in_public_folder",
+                "public_file.py",
+            ],
+        )
+        # check templates was resolved if needed (non here)
+        assert (tmpdir / "export" / "task1" / "test.txt").read_text(encoding="utf-8") == "Some Changes"
+        assert (tmpdir / "export" / "task2" / "test.txt").read_text(encoding="utf-8") == "Student changed it"
+        assert (tmpdir / "export" / "just_file").read_text(encoding="utf-8") == "hey"
+        # overwritten to public tests
+        assert (tmpdir / "export" / "public_folder" / "file_in_public_folder").read_text(encoding="utf-8") == "file"
+        assert (tmpdir / "export" / "task1" / "public_file.py").read_text(encoding="utf-8") == "print('Hello')\n"
+
+    def test_export_for_contribution(self, tmpdir: Path, simple_exporter: Exporter) -> None:
+        simple_exporter.export_for_contribution(Path(tmpdir / "export"))
+
+        assert_files_in_folder(
+            Path(tmpdir / "export").resolve(),
+            [
+                "task1/.task.yml",
+                "task1/test.txt",
+                "task1/public_file.py",
+                "task2/.task.yml",
+                "task2/test.txt",
+                "task2/.private.file",
+                ".private.file",
+                "just_file",
+                "public_folder/file_in_public_folder",
+                "public_file.py",
+            ],
+        )
+        # check templates was resolved if needed (non here)
+        assert (tmpdir / "export" / "task1" / "test.txt").read_text(encoding="utf-8") == "Some TEMPLATE START\nHello\nTEMPLATE END\n"
+        assert (tmpdir / "export" / "task2" / "test.txt").read_text(encoding="utf-8") == "Some"
+        assert (tmpdir / "export" / "public_folder" / "file_in_public_folder").read_text(encoding="utf-8") == "try to change"
+        assert (tmpdir / "export" / "task1" / "public_file.py").read_text(encoding="utf-8") == "print('Hello LOL this too')\n"
+
+
+class _TestExporter:
     SAMPLE_TEST_DEADLINES_CONFIG = DeadlinesConfig(
         version=1,
         settings={"timezone": "Europe/Berlin"},
@@ -61,6 +401,10 @@ class TestExporter:
         public_patterns=[".private_exception", ".group.yml"],  # note: .task.yml ignored by default
         private_patterns=[".*", "private.*"],
     )
+    SAMPLE_EXPORT_CONFIG = CheckerExportConfig(
+        destination="https://example.com",
+        templates="search_or_create",
+    )
     SAMPLE_TEST_FILES = {
         ".ignore_folder": {
             "folder": {
@@ -88,15 +432,17 @@ class TestExporter:
         "group": {
             "task1": {
                 ".task.yml": "version: 1\nstructure:\n    private_patterns: []\n",
-                "test.txt": "Hello\n",
+                "test.txt": "TEMPLATE START\nHello\nTEMPLATE END\n",
                 ".test.py": "print('Hello')\n",  # not private anymore, override
             },
             "task2": {
                 "junk_group_folder": {"some_junk_file.txt": "Junk\n"},
+                "junk_group_folder.template": "",  # will delete junk_group_folder
                 ".task.yml": "version: 1",
                 "private.txt": "Private\n",
                 "private.py": "print('Private')\n",
                 "valid.txt": "Valid\n",
+                "valid.txt.template": "Valid Template\n",
             },
             "junk_file.py": "123",
             ".group.yml": "version: 1\nstructure:\n    ignore_patterns: [junk_group_folder, junk_file.py]\n",
@@ -105,6 +451,7 @@ class TestExporter:
             ".task.yml": "version: 1\nstructure:\n    public_patterns: []\n",
             ".private_exception": "Some line\n",  # not public anymore, override
             "test.txt": "Hello\n",
+            "test.txt.template": "Hello Template\n",
         },
         "test.py": "print('Hello')\n",
         "test.txt": "Hello\n",
@@ -114,7 +461,7 @@ class TestExporter:
         "private.py": "print('Private')\n",
     }
 
-    def test_validate_ok_no_task_configs(
+    def test_validate_ok_simple(
         self, tmpdir: Path, generate_file_structure: T_GENERATE_FILE_STRUCTURE
     ) -> None:
         structure_config = CheckerStructureConfig(
@@ -124,7 +471,121 @@ class TestExporter:
         )
         generate_file_structure(
             {
-                "folder": {"test.txt": "Hello\n"},
+                "task1": {".task.yml": "version: 1\n", "test.txt": "TEMPLATE START\nHello\nTEMPLATE END\n"},
+                "test.py": "print('Hello')\n",
+            },
+            root=Path(tmpdir / "repository"),
+        )
+        course = Course(
+            deadlines=DeadlinesConfig(
+                version=1,
+                settings={"timezone": "Europe/Berlin"},
+                schedule=[
+                    {
+                        "group": "no_folder_group",
+                        "enabled": True,
+                        "start": "2021-01-01 00:00:00",
+                        "tasks": [
+                            {"task": "task1", "score": 1},
+                        ],
+                    },
+                ],
+            ),
+            repository_root=Path(tmpdir / "repository"),
+        )
+        exporter = Exporter(
+            course,
+            structure_config,
+            self.SAMPLE_EXPORT_CONFIG,
+            Path(tmpdir / "repository"),
+        )
+        exporter.validate()
+
+
+    def test_search_for_exclude_due_templates(
+            self,
+            tmpdir: Path,
+            generate_file_structure: T_GENERATE_FILE_STRUCTURE,
+            file_structure: dict[str, Any],
+            expected_excluded_paths: list[str],
+    ) -> None:
+        generate_file_structure(self.SAMPLE_TEST_FILES, root=Path(tmpdir / "repository"))
+        course = Course(
+            deadlines=self.SAMPLE_TEST_DEADLINES_CONFIG,
+            repository_root=Path(tmpdir / "repository"),
+        )
+        exporter = Exporter(
+            course,
+            self.SAMPLE_TEST_STRUCTURE_CONFIG,
+            self.SAMPLE_EXPORT_CONFIG,
+            Path(tmpdir / "repository"),
+        )
+
+        generate_file_structure(file_structure, root=Path(tmpdir / "test_data"))
+        excluded_paths = exporter._search_for_exclude_due_to_templates(Path(tmpdir / "test_data"), False)
+        assert sorted(path_name for path_name in excluded_paths) == sorted(expected_excluded_paths)
+
+    @pytest.mark.parametrize(
+        "file_content", [
+            "TEM!PLATE START\nHello\nTEMPLATE END\n",
+            "TEMPLATE START\nHello\nTEMPL!ATE END\n",
+            "Hello\n",
+            "TEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE START\nHello\nTEMP!LATE END\n",
+            "TEMPLATE START\nHello\nTEMPLATE END\n\nHello\nTEMPLATE END\n",
+            "TEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE START\nHello\n",
+            "TEMPLATE START\nTEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE END",
+        ]
+    )
+    def test_validate_template_wrong_template_comments(
+        self, tmpdir: Path, generate_file_structure: T_GENERATE_FILE_STRUCTURE, file_content: str,
+    ) -> None:
+        structure_config = CheckerStructureConfig(
+            ignore_patterns=[".gitignore"],
+            private_patterns=[".*"],
+            public_patterns=["*"],
+        )
+        generate_file_structure(
+            {
+                "task1": {".task.yml": "version: 1\n", "test.txt": file_content},
+                "test.py": "print('Hello')\n",
+            },
+            root=Path(tmpdir / "repository"),
+        )
+        course = Course(
+            deadlines=DeadlinesConfig(
+                version=1,
+                settings={"timezone": "Europe/Berlin"},
+                schedule=[
+                    {
+                        "group": "no_folder_group",
+                        "enabled": True,
+                        "start": "2021-01-01 00:00:00",
+                        "tasks": [
+                            {"task": "task1", "score": 1},
+                        ],
+                    },
+                ],
+            ),
+            repository_root=Path(tmpdir / "repository"),
+        )
+        exporter = Exporter(
+            course,
+            structure_config,
+            CheckerExportConfig(destination="https://example.com", templates="create"),
+            Path(tmpdir / "repository"),
+        )
+        with pytest.raises(BadStructure):
+            exporter.validate()
+
+    def test_validate_template_search_ok(self, tmpdir: Path, generate_file_structure: T_GENERATE_FILE_STRUCTURE) -> None:
+        structure_config = CheckerStructureConfig(
+            ignore_patterns=[".gitignore"],
+            private_patterns=[".*"],
+            public_patterns=["*"],
+        )
+        generate_file_structure(
+            {
+                "folder": {"test.txt.template": "Hello\n"},
                 "test.py": "print('Hello')\n",
             },
             root=Path(tmpdir / "repository"),
@@ -136,67 +597,11 @@ class TestExporter:
         exporter = Exporter(
             course,
             structure_config,
-            CheckerExportConfig(destination="https://example.com"),
-            Path(tmpdir / "repository"),
-        )
-        exporter.validate()
-
-    def test_validate_ok_task_configs(self, tmpdir: Path, generate_file_structure: T_GENERATE_FILE_STRUCTURE) -> None:
-        structure_config = CheckerStructureConfig(
-            ignore_patterns=[".gitignore"],
-            private_patterns=[".*"],
-            public_patterns=["*"],
-        )
-        generate_file_structure(
-            {
-                "folder": {".task.yml": "version: 1\n", "test.txt": "Hello\n"},
-                "test.py": "print('Hello')\n",
-            },
-            root=Path(tmpdir / "repository"),
-        )
-        course = Course(
-            deadlines=self.SAMPLE_TEST_DEADLINES_CONFIG,
-            repository_root=Path(tmpdir / "repository"),
-        )
-        exporter = Exporter(
-            course,
-            structure_config,
-            CheckerExportConfig(destination="https://example.com"),
+            self.SAMPLE_EXPORT_CONFIG,
             Path(tmpdir / "repository"),
         )
 
         exporter.validate()
-
-    def test_validate_fail_wrong_task_config(
-        self, tmpdir: Path, generate_file_structure: T_GENERATE_FILE_STRUCTURE
-    ) -> None:
-        _ = CheckerStructureConfig(
-            ignore_patterns=[".gitignore"],
-            private_patterns=[".*"],
-            public_patterns=["*"],
-        )
-        generate_file_structure(
-            {
-                "folder": {".task.yml": "wrong_field: HEHE\n", "test.txt": "Hello\n"},
-                "test.py": "print('Hello')\n",
-            },
-            root=Path(tmpdir / "repository"),
-        )
-        with pytest.raises(BadConfig):
-            course = Course(
-                deadlines=self.SAMPLE_TEST_DEADLINES_CONFIG,
-                repository_root=Path(tmpdir / "repository"),
-            )
-            course.validate()
-
-        # exporter = Exporter(
-        #     course,
-        #     structure_config,
-        #     CheckerExportConfig(destination="https://example.com"),
-        #     Path(tmpdir / "repository"),
-        # )
-        # with pytest.raises(BadConfig):
-        #     exporter.validate()
 
     def test_export_public(self, tmpdir: Path, generate_file_structure: T_GENERATE_FILE_STRUCTURE) -> None:
         generate_file_structure(self.SAMPLE_TEST_FILES, root=Path(tmpdir / "repository"))
@@ -207,7 +612,7 @@ class TestExporter:
         exporter = Exporter(
             course,
             self.SAMPLE_TEST_STRUCTURE_CONFIG,
-            CheckerExportConfig(destination="https://example.com"),
+            self.SAMPLE_EXPORT_CONFIG,
             Path(tmpdir / "repository"),
         )
 
@@ -240,7 +645,7 @@ class TestExporter:
         exporter = Exporter(
             course,
             self.SAMPLE_TEST_STRUCTURE_CONFIG,
-            CheckerExportConfig(destination="https://example.com"),
+            self.SAMPLE_EXPORT_CONFIG,
             Path(tmpdir / "repository"),
         )
 
@@ -285,7 +690,7 @@ class TestExporter:
         exporter = Exporter(
             course,
             self.SAMPLE_TEST_STRUCTURE_CONFIG,
-            CheckerExportConfig(destination="https://example.com"),
+            self.SAMPLE_EXPORT_CONFIG,
             Path(tmpdir / "repository"),
         )
 

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -7,7 +7,7 @@ import pytest
 
 from checker.configs import CheckerExportConfig, CheckerStructureConfig, DeadlinesConfig
 from checker.course import Course
-from checker.exceptions import BadConfig, BadStructure
+from checker.exceptions import BadStructure
 from checker.exporter import Exporter
 
 from .conftest import T_GENERATE_FILE_STRUCTURE
@@ -61,8 +61,18 @@ class TestExporterOnSimple:
     @pytest.fixture()
     def simple_private_layout(self, tmpdir: Path, generate_file_structure: T_GENERATE_FILE_STRUCTURE) -> Path:
         layout = {
-            "task1": {".task.yml": "version: 1\nstructure:\n    ignore_patterns: [extra_ignore_me]\n", "test.txt": "Some TEMPLATE START\nHello\nTEMPLATE END\n", "public_file.py": "print('Hello')\n", "extra_ignore_me": ""},
-            "task2": {".task.yml": "", "test.txt": "Some", "test.txt.template": "Will replace the file", ".private.file": "private\n"},
+            "task1": {
+                ".task.yml": "version: 1\nstructure:\n    ignore_patterns: [extra_ignore_me]\n",
+                "test.txt": "Some TEMPLATE START\nHello\nTEMPLATE END\n",
+                "public_file.py": "print('Hello')\n",
+                "extra_ignore_me": "",
+            },
+            "task2": {
+                ".task.yml": "",
+                "test.txt": "Some",
+                "test.txt.template": "Will replace the file",
+                ".private.file": "private\n",
+            },
             ".ignore_me": "",
             "just_file": "hey",
             ".private.file": "private\n",
@@ -113,13 +123,17 @@ class TestExporterOnSimple:
         Path(tmpdir / "repository" / "task1" / "new.txt").touch()
         Path(tmpdir / "repository" / "task1" / "new.txt.template").touch()
         Path(tmpdir / "repository" / "task2" / "new.txt").touch()
-        Path(tmpdir / "repository" / "task2" / "new.txt").write_text("Some\n TEMPLATE START\nHello\nTEMPLATE END\n", encoding="utf-8")
+        Path(tmpdir / "repository" / "task2" / "new.txt").write_text(
+            "Some\n TEMPLATE START\nHello\nTEMPLATE END\n", encoding="utf-8"
+        )
 
         with pytest.raises(BadStructure) as exc_info:
             simple_exporter.validate()
         assert "use both" in str(exc_info.value)
 
-    @pytest.mark.parametrize("template_type", [CheckerExportConfig.TemplateType.CREATE, CheckerExportConfig.TemplateType.SEARCH])
+    @pytest.mark.parametrize(
+        "template_type", [CheckerExportConfig.TemplateType.CREATE, CheckerExportConfig.TemplateType.SEARCH]
+    )
     def test_simple_validate_no_templates(self, tmpdir: Path, simple_exporter: Exporter, template_type: str) -> None:
         simple_exporter.export_config.templates = template_type
 
@@ -131,8 +145,12 @@ class TestExporterOnSimple:
             simple_exporter.validate()
         assert "Have to include at least" in str(exc_info.value)
 
-    @pytest.mark.parametrize("template_type", [CheckerExportConfig.TemplateType.SEARCH, CheckerExportConfig.TemplateType.SEARCH_OR_CREATE])
-    def test_simple_validate_no_original_file_for_templates(self, tmpdir: Path, simple_exporter: Exporter, template_type: str) -> None:
+    @pytest.mark.parametrize(
+        "template_type", [CheckerExportConfig.TemplateType.SEARCH, CheckerExportConfig.TemplateType.SEARCH_OR_CREATE]
+    )
+    def test_simple_validate_no_original_file_for_templates(
+        self, tmpdir: Path, simple_exporter: Exporter, template_type: str
+    ) -> None:
         simple_exporter.export_config.templates = template_type
 
         # delete all templates files
@@ -143,8 +161,12 @@ class TestExporterOnSimple:
             simple_exporter.validate()
         assert "does not have original" in str(exc_info.value)
 
-    @pytest.mark.parametrize("template_type", [CheckerExportConfig.TemplateType.CREATE, CheckerExportConfig.TemplateType.SEARCH])
-    def test_simple_validate_wrong_template_type(self, tmpdir: Path, simple_exporter: Exporter, template_type: str) -> None:
+    @pytest.mark.parametrize(
+        "template_type", [CheckerExportConfig.TemplateType.CREATE, CheckerExportConfig.TemplateType.SEARCH]
+    )
+    def test_simple_validate_wrong_template_type(
+        self, tmpdir: Path, simple_exporter: Exporter, template_type: str
+    ) -> None:
         simple_exporter.export_config.templates = template_type
 
         with pytest.raises(BadStructure) as exc_info:
@@ -152,7 +174,8 @@ class TestExporterOnSimple:
         assert "Templating set to" in str(exc_info.value)
 
     @pytest.mark.parametrize(
-        "file_content", [
+        "file_content",
+        [
             "TEM!PLATE START\nHello\nTEMPLATE END\n",
             "TEMPLATE START\nHello\nTEMPL!ATE END\n",
             "Hello\n",
@@ -160,9 +183,11 @@ class TestExporterOnSimple:
             "TEMPLATE START\nHello\nTEMPLATE END\n\nHello\nTEMPLATE END\n",
             "TEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE START\nHello\n",
             "TEMPLATE START\nTEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE END",
-        ]
+        ],
     )
-    def test_simple_validate_wrong_template_comment(self, tmpdir: Path, simple_exporter: Exporter, file_content: str) -> None:
+    def test_simple_validate_wrong_template_comment(
+        self, tmpdir: Path, simple_exporter: Exporter, file_content: str
+    ) -> None:
         simple_exporter.export_config.templates = CheckerExportConfig.TemplateType.CREATE
 
         # remove .template and write comment-style template
@@ -171,7 +196,9 @@ class TestExporterOnSimple:
 
         with pytest.raises(BadStructure) as exc_info:
             simple_exporter.validate()
-        assert "invalid template comments" in str(exc_info.value) or "does not have template comments" in str(exc_info.value)
+        assert "invalid template comments" in str(exc_info.value) or "does not have template comments" in str(
+            exc_info.value
+        )
 
     # TODO: ignore_templates tests
     @pytest.mark.parametrize(
@@ -186,19 +213,34 @@ class TestExporterOnSimple:
                 [],
             ),
             (
-                {"some_folder": {"some_file.txt": "123", "not_in_the_root_folder.py": "TEMPLATE START\nTEMPLATE END"}, "other_file": "123"},
+                {
+                    "some_folder": {
+                        "some_file.txt": "123",
+                        "not_in_the_root_folder.py": "TEMPLATE START\nTEMPLATE END",
+                    },
+                    "other_file": "123",
+                },
                 [],  # search in current dir only
             ),
             (
-                {"some_folder": {"some_file.txt": "123"}, "empty_after_template_file.py": "TEMPLATE START\nTEMPLATE END"},
+                {
+                    "some_folder": {"some_file.txt": "123"},
+                    "empty_after_template_file.py": "TEMPLATE START\nTEMPLATE END",
+                },
                 ["empty_after_template_file.py"],
             ),
             (
-                {"some_folder": {"some_file.txt": "123"}, "empty_after_template_file.py": "   \n\n  TEMPLATE START\n\nTEMPLATE END\n\t\n"},
-                ["empty_after_template_file.py"]
+                {
+                    "some_folder": {"some_file.txt": "123"},
+                    "empty_after_template_file.py": "   \n\n  TEMPLATE START\n\nTEMPLATE END\n\t\n",
+                },
+                ["empty_after_template_file.py"],
             ),
             (
-                {"some_folder": {"some_file.txt.template": "123", "some_file.txt": "321", "empty_file.py": ""}, "other_file": "123"},
+                {
+                    "some_folder": {"some_file.txt.template": "123", "some_file.txt": "321", "empty_file.py": ""},
+                    "other_file": "123",
+                },
                 [],  # search in current dir only
             ),
             (
@@ -206,16 +248,32 @@ class TestExporterOnSimple:
                 ["some_file.txt"],
             ),
             (
-                {"some_folder.template": {"some_file.txt": "123", "empty_file.py": ""}, "some_folder": {"some_file": ""}, "other_file": "123"},
+                {
+                    "some_folder.template": {"some_file.txt": "123", "empty_file.py": ""},
+                    "some_folder": {"some_file": ""},
+                    "other_file": "123",
+                },
                 ["some_folder"],
             ),
             (
-                {"some_folder": {"some_file.txt.template": "123", "some_file.txt": "321", "empty_file.py": ""}, "other_file": "TEMPLATE START\nTEMPLATE END", "other_other_file": "", "other_other_file.template": ""},
+                {
+                    "some_folder": {"some_file.txt.template": "123", "some_file.txt": "321", "empty_file.py": ""},
+                    "other_file": "TEMPLATE START\nTEMPLATE END",
+                    "other_other_file": "",
+                    "other_other_file.template": "",
+                },
                 ["other_other_file", "other_file"],
             ),
         ],
     )
-    def test_search_for_exclude_due_to_templates(self, tmpdir: Path, simple_exporter: Exporter, generate_file_structure: T_GENERATE_FILE_STRUCTURE, file_structure: dict[str, Any], expected_excluded_paths: list[str]) -> None:
+    def test_search_for_exclude_due_to_templates(
+        self,
+        tmpdir: Path,
+        simple_exporter: Exporter,
+        generate_file_structure: T_GENERATE_FILE_STRUCTURE,
+        file_structure: dict[str, Any],
+        expected_excluded_paths: list[str],
+    ) -> None:
         # use other directory, not original Exporter one
         generate_file_structure(file_structure, root=Path(tmpdir / "test_data"))
 
@@ -228,12 +286,22 @@ class TestExporterOnSimple:
             (True, False, False, ["task1/public_file.py", "public_file.py", "public_folder/file_in_public_folder"]),
             (False, True, False, ["task1/.task.yml", "task2/.task.yml", "task2/.private.file", ".private.file"]),
             (False, False, True, ["task1/test.txt", "task2/test.txt", "just_file"]),
-        ]
+        ],
     )
     @pytest.mark.parametrize(
-        "fill_templates", [True, False],
+        "fill_templates",
+        [True, False],
     )
-    def test_copy_files_with_config(self, tmpdir: Path, simple_exporter: Exporter, copy_public: bool, copy_private: bool, copy_other: bool, expected_files: list[str], fill_templates: bool) -> None:
+    def test_copy_files_with_config(
+        self,
+        tmpdir: Path,
+        simple_exporter: Exporter,
+        copy_public: bool,
+        copy_private: bool,
+        copy_other: bool,
+        expected_files: list[str],
+        fill_templates: bool,
+    ) -> None:
         source = Path(tmpdir / "repository")
         destination = Path(tmpdir / "export")
 
@@ -244,7 +312,9 @@ class TestExporterOnSimple:
         assert_files_in_folder(destination, expected_files)
 
     @pytest.mark.parametrize("is_file", [True, False])
-    def test_copy_files_with_config_empty_template(self, tmpdir: Path, simple_exporter: Exporter, is_file: bool) -> None:
+    def test_copy_files_with_config_empty_template(
+        self, tmpdir: Path, simple_exporter: Exporter, is_file: bool
+    ) -> None:
         # set .template as empty file/folder will delete original file
         if is_file:
             Path(tmpdir / "repository" / "task2" / "test.txt.template").write_text("", encoding="utf-8")
@@ -253,14 +323,22 @@ class TestExporterOnSimple:
             Path(tmpdir / "repository" / "task2" / "test.txt.template").mkdir()
 
         simple_exporter._copy_files_with_config(
-            Path(tmpdir / "repository"), Path(tmpdir / "export"), simple_exporter.structure_config, False, False, True, True,
+            Path(tmpdir / "repository"),
+            Path(tmpdir / "export"),
+            simple_exporter.structure_config,
+            False,
+            False,
+            True,
+            True,
         )
 
         assert_files_in_folder(Path(tmpdir / "export"), ["task1/test.txt", "just_file"])
 
     @pytest.mark.parametrize("is_source_file", [True, False])
     @pytest.mark.parametrize("is_destination_file", [True, False])
-    def test_copy_files_with_config_template_is_file_or_folder(self, tmpdir: Path, simple_exporter: Exporter, is_source_file: bool, is_destination_file: bool) -> None:
+    def test_copy_files_with_config_template_is_file_or_folder(
+        self, tmpdir: Path, simple_exporter: Exporter, is_source_file: bool, is_destination_file: bool
+    ) -> None:
         repository = Path(tmpdir / "repository")
         export = Path(tmpdir / "export")
 
@@ -283,7 +361,13 @@ class TestExporterOnSimple:
             Path(repository / "task2" / "test.txt" / "old_file.txt").write_text("OLD TEXT", encoding="utf-8")
 
         simple_exporter._copy_files_with_config(
-            repository, export, simple_exporter.structure_config, False, False, True, True,
+            repository,
+            export,
+            simple_exporter.structure_config,
+            False,
+            False,
+            True,
+            True,
         )
 
         # regardless of original file - just copy there template
@@ -358,10 +442,16 @@ class TestExporterOnSimple:
             ],
         )
         # check templates was resolved if needed (non here)
-        assert (tmpdir / "export" / "task1" / "test.txt").read_text(encoding="utf-8") == "Some TEMPLATE START\nHello\nTEMPLATE END\n"
+        assert (tmpdir / "export" / "task1" / "test.txt").read_text(
+            encoding="utf-8"
+        ) == "Some TEMPLATE START\nHello\nTEMPLATE END\n"
         assert (tmpdir / "export" / "task2" / "test.txt").read_text(encoding="utf-8") == "Some"
-        assert (tmpdir / "export" / "public_folder" / "file_in_public_folder").read_text(encoding="utf-8") == "try to change"
-        assert (tmpdir / "export" / "task1" / "public_file.py").read_text(encoding="utf-8") == "print('Hello LOL this too')\n"
+        assert (tmpdir / "export" / "public_folder" / "file_in_public_folder").read_text(
+            encoding="utf-8"
+        ) == "try to change"
+        assert (tmpdir / "export" / "task1" / "public_file.py").read_text(
+            encoding="utf-8"
+        ) == "print('Hello LOL this too')\n"
 
 
 class _TestExporter:
@@ -461,9 +551,7 @@ class _TestExporter:
         "private.py": "print('Private')\n",
     }
 
-    def test_validate_ok_simple(
-        self, tmpdir: Path, generate_file_structure: T_GENERATE_FILE_STRUCTURE
-    ) -> None:
+    def test_validate_ok_simple(self, tmpdir: Path, generate_file_structure: T_GENERATE_FILE_STRUCTURE) -> None:
         structure_config = CheckerStructureConfig(
             ignore_patterns=[".gitignore"],
             private_patterns=[".*"],
@@ -501,13 +589,12 @@ class _TestExporter:
         )
         exporter.validate()
 
-
     def test_search_for_exclude_due_templates(
-            self,
-            tmpdir: Path,
-            generate_file_structure: T_GENERATE_FILE_STRUCTURE,
-            file_structure: dict[str, Any],
-            expected_excluded_paths: list[str],
+        self,
+        tmpdir: Path,
+        generate_file_structure: T_GENERATE_FILE_STRUCTURE,
+        file_structure: dict[str, Any],
+        expected_excluded_paths: list[str],
     ) -> None:
         generate_file_structure(self.SAMPLE_TEST_FILES, root=Path(tmpdir / "repository"))
         course = Course(
@@ -526,7 +613,8 @@ class _TestExporter:
         assert sorted(path_name for path_name in excluded_paths) == sorted(expected_excluded_paths)
 
     @pytest.mark.parametrize(
-        "file_content", [
+        "file_content",
+        [
             "TEM!PLATE START\nHello\nTEMPLATE END\n",
             "TEMPLATE START\nHello\nTEMPL!ATE END\n",
             "Hello\n",
@@ -534,10 +622,13 @@ class _TestExporter:
             "TEMPLATE START\nHello\nTEMPLATE END\n\nHello\nTEMPLATE END\n",
             "TEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE START\nHello\n",
             "TEMPLATE START\nTEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE END",
-        ]
+        ],
     )
     def test_validate_template_wrong_template_comments(
-        self, tmpdir: Path, generate_file_structure: T_GENERATE_FILE_STRUCTURE, file_content: str,
+        self,
+        tmpdir: Path,
+        generate_file_structure: T_GENERATE_FILE_STRUCTURE,
+        file_content: str,
     ) -> None:
         structure_config = CheckerStructureConfig(
             ignore_patterns=[".gitignore"],
@@ -577,7 +668,9 @@ class _TestExporter:
         with pytest.raises(BadStructure):
             exporter.validate()
 
-    def test_validate_template_search_ok(self, tmpdir: Path, generate_file_structure: T_GENERATE_FILE_STRUCTURE) -> None:
+    def test_validate_template_search_ok(
+        self, tmpdir: Path, generate_file_structure: T_GENERATE_FILE_STRUCTURE
+    ) -> None:
         structure_config = CheckerStructureConfig(
             ignore_patterns=[".gitignore"],
             private_patterns=[".*"],

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -63,7 +63,7 @@ class TestExporterOnSimple:
         layout = {
             "task1": {
                 ".task.yml": "version: 1\nstructure:\n    ignore_patterns: [extra_ignore_me]\n",
-                "test.txt": "Some TEMPLATE START\nHello\nTEMPLATE END\n",
+                "test.txt": "Some SOLUTION BEGIN\nHello\nSOLUTION END\n",
                 "public_file.py": "print('Hello')\n",
                 "extra_ignore_me": "",
             },
@@ -124,7 +124,7 @@ class TestExporterOnSimple:
         Path(tmpdir / "repository" / "task1" / "new.txt.template").touch()
         Path(tmpdir / "repository" / "task2" / "new.txt").touch()
         Path(tmpdir / "repository" / "task2" / "new.txt").write_text(
-            "Some\n TEMPLATE START\nHello\nTEMPLATE END\n", encoding="utf-8"
+            "Some\n SOLUTION BEGIN\nHello\nSOLUTION END\n", encoding="utf-8"
         )
 
         with pytest.raises(BadStructure) as exc_info:
@@ -176,13 +176,13 @@ class TestExporterOnSimple:
     @pytest.mark.parametrize(
         "file_content",
         [
-            "TEM!PLATE START\nHello\nTEMPLATE END\n",
-            "TEMPLATE START\nHello\nTEMPL!ATE END\n",
+            "WRONG_START\nHello\nSOLUTION END\n",
+            "SOLUTION BEGIN\nHello\nWRONG\n",
             "Hello\n",
-            "TEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE START\nHello\nTEMP!LATE END\n",
-            "TEMPLATE START\nHello\nTEMPLATE END\n\nHello\nTEMPLATE END\n",
-            "TEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE START\nHello\n",
-            "TEMPLATE START\nTEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE END",
+            "SOLUTION BEGIN\nHello\nSOLUTION END\nSOLUTION BEGIN\nHello\nWRONG\n",
+            "SOLUTION BEGIN\nHello\nSOLUTION END\n\nHello\nSOLUTION END\n",
+            "SOLUTION BEGIN\nHello\nSOLUTION END\nSOLUTION BEGIN\nHello\n",
+            "SOLUTION BEGIN\nSOLUTION BEGIN\nHello\nSOLUTION END\nSOLUTION END",
         ],
     )
     def test_simple_validate_wrong_template_comment(
@@ -216,7 +216,7 @@ class TestExporterOnSimple:
                 {
                     "some_folder": {
                         "some_file.txt": "123",
-                        "not_in_the_root_folder.py": "TEMPLATE START\nTEMPLATE END",
+                        "not_in_the_root_folder.py": "SOLUTION BEGIN\nSOLUTION END",
                     },
                     "other_file": "123",
                 },
@@ -225,14 +225,14 @@ class TestExporterOnSimple:
             (
                 {
                     "some_folder": {"some_file.txt": "123"},
-                    "empty_after_template_file.py": "TEMPLATE START\nTEMPLATE END",
+                    "empty_after_template_file.py": "SOLUTION BEGIN\nSOLUTION END",
                 },
                 ["empty_after_template_file.py"],
             ),
             (
                 {
                     "some_folder": {"some_file.txt": "123"},
-                    "empty_after_template_file.py": "   \n\n  TEMPLATE START\n\nTEMPLATE END\n\t\n",
+                    "empty_after_template_file.py": "   \n\n  SOLUTION BEGIN\n\nSOLUTION END\n\t\n",
                 },
                 ["empty_after_template_file.py"],
             ),
@@ -258,7 +258,7 @@ class TestExporterOnSimple:
             (
                 {
                     "some_folder": {"some_file.txt.template": "123", "some_file.txt": "321", "empty_file.py": ""},
-                    "other_file": "TEMPLATE START\nTEMPLATE END",
+                    "other_file": "SOLUTION BEGIN\nSOLUTION END",
                     "other_other_file": "",
                     "other_other_file.template": "",
                 },
@@ -394,7 +394,7 @@ class TestExporterOnSimple:
             ],
         )
         # check templates was resolved if needed (all here)
-        assert (tmpdir / "export" / "task1" / "test.txt").read_text(encoding="utf-8") == "Some TODO: Your code\n"
+        assert (tmpdir / "export" / "task1" / "test.txt").read_text(encoding="utf-8") == "Some TODO: Your solution\n"
         assert (tmpdir / "export" / "task2" / "test.txt").read_text(encoding="utf-8") == "Will replace the file"
 
     def test_export_for_testing(self, tmpdir: Path, simple_exporter: Exporter) -> None:
@@ -444,7 +444,7 @@ class TestExporterOnSimple:
         # check templates was resolved if needed (non here)
         assert (tmpdir / "export" / "task1" / "test.txt").read_text(
             encoding="utf-8"
-        ) == "Some TEMPLATE START\nHello\nTEMPLATE END\n"
+        ) == "Some SOLUTION BEGIN\nHello\nSOLUTION END\n"
         assert (tmpdir / "export" / "task2" / "test.txt").read_text(encoding="utf-8") == "Some"
         assert (tmpdir / "export" / "public_folder" / "file_in_public_folder").read_text(
             encoding="utf-8"
@@ -522,7 +522,7 @@ class _TestExporter:
         "group": {
             "task1": {
                 ".task.yml": "version: 1\nstructure:\n    private_patterns: []\n",
-                "test.txt": "TEMPLATE START\nHello\nTEMPLATE END\n",
+                "test.txt": "SOLUTION BEGIN\nHello\nSOLUTION END\n",
                 ".test.py": "print('Hello')\n",  # not private anymore, override
             },
             "task2": {
@@ -559,7 +559,7 @@ class _TestExporter:
         )
         generate_file_structure(
             {
-                "task1": {".task.yml": "version: 1\n", "test.txt": "TEMPLATE START\nHello\nTEMPLATE END\n"},
+                "task1": {".task.yml": "version: 1\n", "test.txt": "SOLUTION BEGIN\nHello\nSOLUTION END\n"},
                 "test.py": "print('Hello')\n",
             },
             root=Path(tmpdir / "repository"),
@@ -615,13 +615,13 @@ class _TestExporter:
     @pytest.mark.parametrize(
         "file_content",
         [
-            "TEM!PLATE START\nHello\nTEMPLATE END\n",
-            "TEMPLATE START\nHello\nTEMPL!ATE END\n",
+            "TEM!PLATE START\nHello\nSOLUTION END\n",
+            "SOLUTION BEGIN\nHello\nTEMPL!ATE END\n",
             "Hello\n",
-            "TEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE START\nHello\nTEMP!LATE END\n",
-            "TEMPLATE START\nHello\nTEMPLATE END\n\nHello\nTEMPLATE END\n",
-            "TEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE START\nHello\n",
-            "TEMPLATE START\nTEMPLATE START\nHello\nTEMPLATE END\nTEMPLATE END",
+            "SOLUTION BEGIN\nHello\nSOLUTION END\nSOLUTION BEGIN\nHello\nTEMP!LATE END\n",
+            "SOLUTION BEGIN\nHello\nSOLUTION END\n\nHello\nSOLUTION END\n",
+            "SOLUTION BEGIN\nHello\nSOLUTION END\nSOLUTION BEGIN\nHello\n",
+            "SOLUTION BEGIN\nSOLUTION BEGIN\nHello\nSOLUTION END\nSOLUTION END",
         ],
     )
     def test_validate_template_wrong_template_comments(


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗
Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
Feel free to set Draft status if you need help or want to discuss. -->

## Description

Add templating mechanism for exporting.

* `templates: "search"` - checker will search for files or folders with `.template` extension in the task directory and use them as templates.  
    Original file/folder will be deleted and replaced with a template (`.template` extension will be removed).  
    For example, if you have `task_1/solution.py.template` file, checker will use it as a template to replace gold solution `task_1/solution.py` file.  
    This is the default option.
    
    If you have an empty file/folder with `.template` extension, checker will just delete original file/folder.

* `templates: "create"` - checker will search for the template comments in your gold solution and will delete everything except the template.  
    For example, if you have `task_1/solution.py` file with a pair of comments `SOLUTION BEGIN` and `SOLUTION END`:
    ```python
    a = 1
    # SOLUTION BEGIN
    print(a)
    # SOLUTION END
    b = a + 1
    b += 1
    # SOLUTION BEGIN
    print(b)
    # SOLUTION END
    ```
    When exporting to public checker will replace it with `TODO: Your solution` in NOT-greedy way:
    ```python
    a = 1
    # TODO: Your solution
    b = a + 1
    b += 1
    # TODO: Your solution
    ```
    Note: You can have multiple templates in one file.  
    Note2: If you write both `SOLUTION BEGIN` and `SOLUTION END` as comments, resulting `TODO: Your solution` will be a comment as well.
    
    If after templating the file is empty, checker will delete it.
  
* `templates: "search_or_create" - checker will try to use `search` and if it fails, it will use `create`.  
   You CAN NOT have 2 types of templating in the same task, but can use any of them in different tasks.  
    
