### PR TITLE
fix: replace print with print_info

### DIFF
--- a/checker/plugins/__init__.py
+++ b/checker/plugins/__init__.py
@@ -7,6 +7,8 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 
+from checker.utils import print_info
+
 from .base import PluginABC, PluginOutput  # noqa: F401
 
 
@@ -38,12 +40,12 @@ def load_plugins(
     ]  # add local plugins first
 
     # force load plugins
-    print("Loading plugins...")
+    print_info("Loading plugins...")
     for module_info in pkgutil.iter_modules([str(path) for path in search_directories]):
         if module_info.name == "__init__":
             continue
         if verbose:
-            print(f"- {module_info.name} from {module_info.module_finder.path}")  # type: ignore[union-attr]
+            print_info(f"- {module_info.name} from {module_info.module_finder.path}")  # type: ignore[union-attr]
 
         spec = module_info.module_finder.find_spec(fullname=module_info.name)  # type: ignore[call-arg]
         if spec is None:
@@ -60,5 +62,5 @@ def load_plugins(
     for subclass in get_all_subclasses(PluginABC):  # type: ignore[type-abstract]
         plugins[subclass.name] = subclass
     if verbose:
-        print(f"Loaded: {', '.join(plugins.keys())}")
+        print_info(f"Loaded: {', '.join(plugins.keys())}")
     return plugins

--- a/checker/tester.py
+++ b/checker/tester.py
@@ -125,15 +125,15 @@ class Tester:
         outputs: dict[str, PipelineStageResult] = {}
 
         # validate global pipeline (only default params and variables available)
-        print("- global pipeline...")
+        print_info("- global pipeline...")
         global_variables = self._get_global_pipeline_parameters(Path(), tasks)
         context = self._get_context(global_variables, None, outputs, self.default_params, None)
         self.global_pipeline.validate(context, validate_placeholders=True)
-        print("  ok")
+        print_info("  ok")
 
         for task in tasks:
             # validate task with global + task-specific params
-            print(f"- task {task.name} pipeline...")
+            print_info(f"- task {task.name} pipeline...")
 
             # create task context
             task_variables = self._get_task_pipeline_parameters(task)
@@ -150,7 +150,7 @@ class Tester:
             self.task_pipeline.validate(context, validate_placeholders=True)
             self.report_pipeline.validate(context, validate_placeholders=True)
 
-            print("  ok")
+            print_info("  ok")
 
     def run(
         self,


### PR DESCRIPTION
Logs in CI are messed up if use **print** and **print_info** at the same time.