### PR TITLE
fix: Use slim instead of alpine in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,57 +1,47 @@
 ARG PYTHON_VERSION=3.12
 
 # Stage 1: Python dependencies
-FROM python:${PYTHON_VERSION}-alpine as builder
+FROM python:${PYTHON_VERSION}-slim AS builder
 
 # Install build tools for cpp and rust
-RUN apk update && apk add --no-cache \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     gawk \
-    linux-headers \
-    build-base \
+    build-essential \
+    libssl-dev \
     cargo \
-    rust \
-    && rm -rf /var/cache/apk/*
+    rustc \
+    && rm -rf /var/lib/apt/lists/*
 
 # Build firejail from source
 RUN git clone --depth 1 --branch 0.9.72 https://github.com/netblue30/firejail.git
 WORKDIR /firejail
-RUN ./configure && make && make install-strip && firejail --version
+RUN ./configure && make && make install-strip
 
 # Install python dependencies
 WORKDIR /usr/src/app
-
-# Copy source code
-COPY pyproject.toml VERSION Makefile setup.py README.md ./
-COPY checker ./checker
-
-# Install python dependencies and checker
+COPY . .
 RUN python -m venv /opt/checker-venv
-RUN /opt/checker-venv/bin/python -m pip install --no-cache-dir --require-virtualenv . && \
-    find /opt/checker-venv -type d -name '__pycache__' -exec rm -r {} + && \
-    find /opt/checker-venv -type d -name 'tests' -exec rm -rf {} + && \
-    find /opt/checker-venv -name '*.pyc' -delete && \
-    find /opt/checker-venv -name '*.pyo' -delete && \
-    rm -rf /tmp/*
+RUN /opt/checker-venv/bin/python -m pip install --no-cache-dir --require-virtualenv . \
+    && find /opt/checker-venv -type d -name '__pycache__' -exec rm -r {} + \
+    && find /opt/checker-venv -name '*.py[co]' -delete
 
 
 # Stage 2: Runtime stage
-FROM python:${PYTHON_VERSION}-alpine
+FROM python:${PYTHON_VERSION}-slim
 
 WORKDIR /usr/src/app
 
 # Install additional tools
-RUN apk update  \
-    && apk add --no-cache \
+RUN apt-get update  \
+    && apt-get install -y --no-install-recommends \
         git
 
-# Copy firejail
+# Copy firejail and python environment
 COPY --from=builder /usr/local/bin/firejail /usr/local/bin/firejail
-
-# Copy python dependencies and checker
 COPY --from=builder /opt/checker-venv /opt/checker-venv
 
-# add checker as alias for "/opt/checker-venv/bin/python -m checker"
+# Create symlink for checker
 RUN ln -s /opt/checker-venv/bin/checker /usr/local/bin/checker
 
 ENTRYPOINT [ "checker" ]


### PR DESCRIPTION
Firejail does not build with alpine currently, hence switching to slim