### PR TITLE
fix: Ask for a full report URL

### DIFF
--- a/checker/plugins/manytask.py
+++ b/checker/plugins/manytask.py
@@ -81,7 +81,7 @@ class ManytaskPlugin(PluginABC):
         session = requests.Session()
         session.mount("https://", adapter)
         session.mount("http://", adapter)
-        response = session.post(url=f"{report_url}api/report", data=data, files=files)
+        response = session.post(url=f"{report_url}", data=data, files=files)
 
         if response.status_code >= 400:
             raise PluginExecutionFailed(f"{response.status_code}: {response.text}")


### PR DESCRIPTION
With changes to Manytask the api handles now depend on thr course name. Hence the old way of constructing report URLs is broken. After this change, we ask for a full report URL, hence we can accomadate both old and new ways of reporting.

Fixes https://github.com/manytask/checker/issues/166